### PR TITLE
Add detailed console logs for segmentation workflow

### DIFF
--- a/index_selecionar_objetos.js
+++ b/index_selecionar_objetos.js
@@ -35,6 +35,7 @@ const BASE_URL = 'https://huggingface.co/datasets/Xenova/transformers.js-docs/re
 const worker = new Worker('worker.js', {
     type: 'module',
 });
+console.log('[index] Worker criado');
 
 // Create elements used to display selected points
 const star = document.createElement('div');
@@ -47,6 +48,7 @@ cross.className = 'icon';
 // Set up message handler
 worker.addEventListener('message', (e) => {
     const { type, data } = e.data;
+    console.log('[index] Mensagem do worker', type);
     if (type === 'ready') {
         modelReady = true;
         statusLabel.textContent = 'Pronto';
@@ -167,6 +169,7 @@ resetButton.addEventListener('click', () => {
 async function segment(data) {
     // Update state
     isEncoded = false;
+    console.log('[index] Segmentando imagem');
     if (!modelReady) {
         statusLabel.textContent = 'Carregando modelo...';
     }
@@ -205,6 +208,7 @@ async function segment(data) {
     cutButton.disabled = true;
 
     // Instruct worker to segment the resized image
+    console.log('[index] Enviando imagem para worker');
     worker.postMessage({ type: 'segment', data: { image: resizedData } });
 }
 
@@ -213,6 +217,7 @@ function handleFiles(files) {
     if (!file) {
         return;
     }
+    console.log('[index] Arquivo selecionado', file.name);
     const reader = new FileReader();
     reader.onload = e => segment(e.target.result);
     reader.readAsDataURL(file);

--- a/src/components/ObjectSelector.tsx
+++ b/src/components/ObjectSelector.tsx
@@ -18,21 +18,26 @@ const ObjectSelector = ({ image }: ObjectSelectorProps) => {
   const [status, setStatus] = useState<string | null>(null);
 
   useEffect(() => {
+    console.log("[ObjectSelector] Criando worker");
     const worker = new Worker(new URL("../../worker_selecionar_objetos.js", import.meta.url), { type: "module" });
     workerRef.current = worker;
 
     const handleMessage = (e: MessageEvent) => {
       const { type, data } = e.data;
       if (type === "ready") {
+        console.log("[ObjectSelector] Worker pronto");
         setModelReady(true);
       } else if (type === "segment_result") {
         if (data === "start") {
+          console.log("[ObjectSelector] Iniciou segmentação");
           setStatus("Segmentando objetos...");
         } else if (data === "done") {
+          console.log("[ObjectSelector] Segmentação concluída");
           setStatus("Segmentação concluída");
           isEncoded.current = true;
         }
       } else if (type === "decode_result") {
+        console.log("[ObjectSelector] Resultado de decode recebido");
         isDecoding.current = false;
         if (isEncoded.current) {
           drawMask(data.mask, data.scores);
@@ -55,6 +60,7 @@ const ObjectSelector = ({ image }: ObjectSelectorProps) => {
   const segment = (data: string) => {
     if (!workerRef.current) return;
     isEncoded.current = false;
+    console.log("[ObjectSelector] Enviando imagem para segmentação");
     setStatus("Segmentando objetos...");
 
     if (imgRef.current) {
@@ -74,6 +80,7 @@ const ObjectSelector = ({ image }: ObjectSelectorProps) => {
   };
 
   const drawMask = (mask: any, scores: number[]) => {
+    console.log("[ObjectSelector] Desenhando máscara");
     const canvas = maskCanvasRef.current;
     const container = containerRef.current;
     if (!canvas || !container) return;
@@ -121,6 +128,7 @@ const ObjectSelector = ({ image }: ObjectSelectorProps) => {
       const point = getPoint(e);
       lastPoints.current = [point];
       isDecoding.current = true;
+      console.log("[ObjectSelector] Decodificando ponto", point);
       workerRef.current?.postMessage({ type: "decode", data: lastPoints.current });
     };
     const handleDown = (e: MouseEvent) => {
@@ -128,6 +136,7 @@ const ObjectSelector = ({ image }: ObjectSelectorProps) => {
       const point = getPoint(e);
       lastPoints.current = [{ point: point.point, label: e.button === 2 ? 0 : 1 }];
       isDecoding.current = true;
+      console.log("[ObjectSelector] Decodificando ponto fixo", lastPoints.current);
       workerRef.current?.postMessage({ type: "decode", data: lastPoints.current });
     };
     const preventContext = (e: MouseEvent) => e.preventDefault();

--- a/src/components/UploadArea.tsx
+++ b/src/components/UploadArea.tsx
@@ -14,10 +14,13 @@ const UploadArea = ({ onImageSelected, renderPreview }: UploadAreaProps) => {
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+    console.log("[UploadArea] Arquivo selecionado", file);
     const reader = new FileReader();
     reader.onload = () => {
       const data = reader.result as string;
+      console.log("[UploadArea] Pré-visualização gerada");
       setPreview(data);
+      console.log("[UploadArea] Chamando onImageSelected");
       onImageSelected?.(data);
     };
     reader.readAsDataURL(file);

--- a/worker_selecionar_objetos.js
+++ b/worker_selecionar_objetos.js
@@ -31,10 +31,12 @@ let image_inputs = null;
 let ready = false;
 
 self.onmessage = async (e) => {
+    console.log('[worker] Mensagem recebida', e.data);
     const [model, processor] = await SegmentAnythingSingleton.getInstance();
     if (!ready) {
         // Indicate that we are ready to accept requests
         ready = true;
+        console.log('[worker] Pronto para receber mensagens');
         self.postMessage({
             type: 'ready',
         });
@@ -46,6 +48,7 @@ self.onmessage = async (e) => {
         image_embeddings = null;
 
     } else if (type === 'segment') {
+        console.log('[worker] Iniciando segmentação');
         // Indicate that we are starting to segment the image
         self.postMessage({
             type: 'segment_result',
@@ -58,6 +61,7 @@ self.onmessage = async (e) => {
         image_embeddings = await model.get_image_embeddings(image_inputs)
 
         // Indicate that we have computed the image embeddings, and we are ready to accept decoding requests
+        console.log('[worker] Segmentação concluída');
         self.postMessage({
             type: 'segment_result',
             data: 'done',
@@ -81,6 +85,7 @@ self.onmessage = async (e) => {
         )
 
         // Generate the mask
+        console.log('[worker] Decodificando pontos');
         const outputs = await model({
             ...image_embeddings,
             input_points,
@@ -95,6 +100,7 @@ self.onmessage = async (e) => {
         );
 
         // Send the result back to the main thread
+        console.log('[worker] Máscara gerada');
         self.postMessage({
             type: 'decode_result',
             data: {


### PR DESCRIPTION
## Summary
- add console logs on image upload
- log worker and segmentation progress in `ObjectSelector`
- log worker lifecycle events in vanilla demo and worker file

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6876be7969c083318e003543cae398c9