### PR TITLE
Add time demo

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify
+import time
 from transformers import pipeline
 import torch
 from PIL import Image
@@ -18,6 +19,12 @@ def detect_objects():
     outputs = detector(image)
     labels = sorted({o['label'] for o in outputs})
     return jsonify({"objects": labels})
+
+
+@app.get("/time")
+def get_time():
+    """Return the current unix timestamp."""
+    return jsonify({"time": time.time()})
 
 
 if __name__ == "__main__":

--- a/src/components/SettingsSidebar.tsx
+++ b/src/components/SettingsSidebar.tsx
@@ -5,14 +5,23 @@ import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 
 interface SettingsSidebarProps {
-  className?: string;
-  objects?: string[];
-  onRemoveObject?: (obj: string) => void;
-  onGenerate?: () => void;
-  disableGenerate?: boolean;
+  className?: string
+  objects?: string[]
+  onRemoveObject?: (obj: string) => void
+  onGenerate?: () => void
+  disableGenerate?: boolean
+  /** Optional handler to demonstrate calling a Python script */
+  onShowTime?: () => void
 }
 
-const SettingsSidebar = ({ className, objects = [], onRemoveObject, onGenerate, disableGenerate }: SettingsSidebarProps) => {
+const SettingsSidebar = ({
+  className,
+  objects = [],
+  onRemoveObject,
+  onGenerate,
+  disableGenerate,
+  onShowTime,
+}: SettingsSidebarProps) => {
   return (
     <div className={cn("w-[25%] mr-8 bg-card rounded-2xl p-4 flex flex-col overflow-y-auto self-stretch", className)}>
         <div className="flex items-center justify-center mb-2 space-x-2">
@@ -78,6 +87,18 @@ const SettingsSidebar = ({ className, objects = [], onRemoveObject, onGenerate, 
                 <span className="text-lg">💎</span>
                 <span className="absolute -top-1 -right-2 bg-background text-foreground text-[10px] rounded-full w-4 h-4 flex items-center justify-center">2</span>
               </span>
+            </Button>
+          </div>
+        )}
+
+        {onShowTime && (
+          <div className="mt-2">
+            <Button
+              variant="gradient"
+              className="w-full flex items-center justify-center"
+              onClick={onShowTime}
+            >
+              Ver tempo
             </Button>
           </div>
         )}

--- a/src/pages/EmptyRoom.tsx
+++ b/src/pages/EmptyRoom.tsx
@@ -23,6 +23,16 @@ const EmptyRoom = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { ready, segment, modelError } = useDeepLab();
 
+  const handleShowTime = async () => {
+    try {
+      const res = await fetch('http://localhost:8000/time');
+      const data = await res.json();
+      alert(`Timestamp: ${data.time}`);
+    } catch (err) {
+      console.error('Failed to fetch time', err);
+    }
+  };
+
   const handleUpload = async (dataUrl: string) => {
     setImage(dataUrl);
     setObjects([]);
@@ -134,6 +144,7 @@ const EmptyRoom = () => {
           objects={objects}
           onRemoveObject={o => setObjects(prev => prev.filter(x => x !== o))}
           disableGenerate={loading}
+          onShowTime={handleShowTime}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `/time` endpoint in Flask server
- extend SettingsSidebar with optional `onShowTime` action
- trigger time fetch from EmptyRoom page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python server/app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_6876cd066904833189e8a7c20143d3e8