### PR TITLE
Fix 'Ver tempo' button error

### DIFF
--- a/src/pages/EmptyRoom.tsx
+++ b/src/pages/EmptyRoom.tsx
@@ -26,6 +26,9 @@ const EmptyRoom = () => {
   const handleShowTime = async () => {
     try {
       const res = await fetch('/time');
+      if (!res.ok) {
+        throw new Error(`Unexpected status ${res.status}`);
+      }
       const data = await res.json();
       alert(`Timestamp: ${data.time}`);
     } catch (err) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,10 @@ export default defineConfig(({ mode }) => ({
     host: true,  // bind explícito em IPv4 + IPv6
     port: 8080,
     open: true,
+    proxy: {
+      '/time': 'http://localhost:8000',
+      '/detect': 'http://localhost:8000',
+    },
   },
   plugins: [
     react(),


### PR DESCRIPTION
## Summary
- add Vite proxy config so /time and /detect go to the Flask backend
- better error handling when fetching `/time`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6877f8cf9a4083318801ebd8a7b8adc7