### PR TITLE
Add Change Style page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import Generations from "./pages/Generations";
 import Projects from "./pages/Projects";
 import NotFound from "./pages/NotFound";
 import Academy from "./pages/Academy";
+import ChangeStyle from "./pages/ChangeStyle";
 import Profile, { ProfileOverview } from "./pages/Profile";
 import ProfilePersonalData from "./pages/ProfilePersonalData";
 import ProfileBilling from "./pages/ProfileBilling";
@@ -30,6 +31,7 @@ const App = () => (
             <Route index element={<Home />} />
             <Route path="empty-room" element={<EmptyRoom />} />
             <Route path="change-objects" element={<ChangeObjects />} />
+            <Route path="change-style" element={<ChangeStyle />} />
             <Route path="improve-render" element={<Index />} />
             <Route path="generations" element={<Generations />} />
             <Route path="projects" element={<Projects />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,6 +36,8 @@ const Header = () => {
     pageTitle = "Esvaziar cômodo";
   } else if (location.pathname === "/change-objects") {
     pageTitle = "Alterar objetos";
+  } else if (location.pathname === "/change-style") {
+    pageTitle = "Mudar Estilo";
   } else if (location.pathname === "/generations") {
     pageTitle = "Minhas gerações";
   } else if (location.pathname === "/academy") {

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ const Sidebar = () => {
     { divider: true },
     { icon: BrushCleaning, label: "Esvaziar Cômodo", path: "/empty-room" },
     { icon: Armchair, label: "Alterar objetos", path: "/change-objects" },
+    { icon: BrushCleaning, label: "Mudar Estilo", path: "/change-style" },
     { icon: PackagePlus, label: "Completar Cômodo", path: "/improve-render" },
   ];
 

--- a/src/components/StyleSidebar.tsx
+++ b/src/components/StyleSidebar.tsx
@@ -1,0 +1,80 @@
+import { Button } from "@/components/ui/button";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+interface StyleSidebarProps {
+  className?: string;
+  disableGenerate?: boolean;
+  onGenerate?: () => void;
+}
+
+const styles = [
+  "Nenhum",
+  "Minimalista",
+  "Boêmio",
+  "Fazenda",
+  "Príncipe Saudita",
+  "Neoclássico",
+  "Eclético",
+  "Parisiense",
+  "Hollywood",
+  "Escandinavo",
+  "Praia",
+  "Japonês",
+  "Meados do Século Moderno",
+  "Retro-futurismo",
+  "Texano",
+  "Matrix",
+];
+
+const StyleSidebar = ({ className, disableGenerate, onGenerate }: StyleSidebarProps) => {
+  return (
+    <div className={cn("w-[25%] mr-8 bg-card rounded-2xl p-4 flex flex-col overflow-y-auto self-stretch", className)}>
+      <div className="flex items-center justify-center mb-2 space-x-2">
+        <div className="inline-flex items-center justify-center w-6 h-6 bg-primary/10 rounded-full">
+          <span className="text-sm">2</span>
+        </div>
+        <h2 className="text-lg font-semibold text-foreground text-center">Detalhe sua imagem</h2>
+      </div>
+      <p className="text-sm text-muted-foreground mb-6 text-center">Descreva essa imagem aqui</p>
+
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Label className="text-sm font-medium text-foreground">Descreva o seu design</Label>
+          <Textarea placeholder="Digite aqui..." className="min-h-[100px] resize-none" />
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sm font-medium text-foreground">Estilo</Label>
+          <Select defaultValue="Nenhum">
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {styles.map((style) => (
+                <SelectItem key={style} value={style.toLowerCase().replace(/\s+/g, '-')}>{style}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {onGenerate && (
+        <div className="mt-6">
+          <Button
+            variant="gradient"
+            className="w-full flex items-center justify-center"
+            onClick={onGenerate}
+            disabled={disableGenerate}
+          >
+            Mudar Estilo
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StyleSidebar;

--- a/src/pages/ChangeStyle.tsx
+++ b/src/pages/ChangeStyle.tsx
@@ -1,0 +1,30 @@
+import UploadArea from "@/components/UploadArea";
+import PreviousGenerations from "@/components/PreviousGenerations";
+import StyleSidebar from "@/components/StyleSidebar";
+
+const ChangeStyle = () => {
+  return (
+    <div className="flex flex-col min-h-[calc(100vh-56px)]">
+      <div className="px-4 py-1">
+          <nav className="flex items-center space-x-1 text-xs mb-0">
+            <span className="text-muted-foreground">Home</span>
+            <span className="mx-2 text-muted-foreground">{'>'}</span>
+            <span className="text-blue-500 font-medium">Mudar Estilo</span>
+          </nav>
+      </div>
+
+      <div className="flex flex-1 items-start overflow-auto">
+        <div className="flex-1 flex flex-col px-2 pt-2 pb-8">
+          <div className="bg-card rounded-2xl overflow-hidden border border-border w-full max-w-5xl mx-auto">
+            <UploadArea />
+            <PreviousGenerations />
+          </div>
+        </div>
+
+        <StyleSidebar className="mr-6 mt-2 self-start flex-none border border-gray-200" />
+      </div>
+    </div>
+  );
+};
+
+export default ChangeStyle;

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -19,6 +19,12 @@ const Home = () => {
       link: "/change-objects"
     },
     {
+      icon: BrushCleaning,
+      title: "Mudar Estilo",
+      description: "Aplique um novo estilo de design ao ambiente.",
+      link: "/change-style"
+    },
+    {
       icon: PackagePlus,
       title: "Completar Cômodo",
       description: "Adicione móveis e decoração automaticamente ao ambiente.",


### PR DESCRIPTION
## Summary
- add a new `ChangeStyle` page similar to Empty Room layout
- add `StyleSidebar` component with design description and style selection
- register route and navigation entries for the new page
- show the new page on the Home page list

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6877fd16b2ac83319df023432d913c11