### PR TITLE
Fix forwardRef closing parenthesis

### DIFF
--- a/src/components/ObjectSelector.tsx
+++ b/src/components/ObjectSelector.tsx
@@ -287,7 +287,7 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
       )}
     </div>
   );
-};
+});
 
 export default ObjectSelector;
 


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis in ObjectSelector component

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6879104e201c8331821dac7838b7088d