### PR TITLE
Enable FLUX inpainting in object edit

### DIFF
--- a/src/components/DescriptionSidebar.tsx
+++ b/src/components/DescriptionSidebar.tsx
@@ -9,6 +9,7 @@ interface DescriptionSidebarProps {
   onDescriptionChange?: (description: string) => void;
   onGenerate?: () => void;
   disableGenerate?: boolean;
+  hideDescription?: boolean;
 }
 
 const DescriptionSidebar = ({
@@ -17,6 +18,7 @@ const DescriptionSidebar = ({
   onDescriptionChange,
   onGenerate,
   disableGenerate,
+  hideDescription,
 }: DescriptionSidebarProps) => {
   return (
     <div className={cn("w-[25%] mr-8 bg-card rounded-2xl p-4 flex flex-col overflow-y-auto self-stretch", className)}>
@@ -26,20 +28,22 @@ const DescriptionSidebar = ({
         </div>
         <h2 className="text-lg font-semibold text-foreground text-center">Detalhe sua imagem</h2>
       </div>
-      <p className="text-sm text-muted-foreground mb-6 text-center">Descreva o que quer mudar</p>
-
-      <div className="space-y-6">
-        {/* Descrição */}
-        <div className="space-y-2">
-          <Label className="text-sm font-medium text-foreground">Descreva o que quer mudar</Label>
-          <Textarea
-            placeholder="Digite aqui o que você quer alterar na imagem..."
-            className="min-h-[150px] resize-none"
-            value={description}
-            onChange={(e) => onDescriptionChange?.(e.target.value)}
-          />
-        </div>
-      </div>
+      {!hideDescription && (
+        <>
+          <p className="text-sm text-muted-foreground mb-6 text-center">Descreva o que quer mudar</p>
+          <div className="space-y-6">
+            <div className="space-y-2">
+              <Label className="text-sm font-medium text-foreground">Descreva o que quer mudar</Label>
+              <Textarea
+                placeholder="Digite aqui o que você quer alterar na imagem..."
+                className="min-h-[150px] resize-none"
+                value={description}
+                onChange={(e) => onDescriptionChange?.(e.target.value)}
+              />
+            </div>
+          </div>
+        </>
+      )}
 
       {/* Generate button */}
       {onGenerate && (

--- a/src/components/ObjectSelector.tsx
+++ b/src/components/ObjectSelector.tsx
@@ -19,6 +19,7 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
   const isEncoded = useRef(false);
   const isDecoding = useRef(false);
   const lastPoints = useRef<{ point: [number, number]; label: number }[]>([]);
+  const selectionFixed = useRef(false);
   const [selectedMasks, setSelectedMasks] = useState<any[]>([]);
   const [currentMask, setCurrentMask] = useState<{mask: any, scores: number[]} | null>(null);
   const [modelReady, setModelReady] = useState(false);
@@ -171,13 +172,14 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
     for (let i = 1; i < numMasks; ++i) {
       if (scores[i] > scores[bestIndex]) bestIndex = i;
     }
-
     setSelectedMasks(prev => [...prev, { mask, scores, numMasks, bestIndex }]);
+    selectionFixed.current = true;
   };
 
   const resetSelections = () => {
     setSelectedMasks([]);
     setCurrentMask(null);
+    selectionFixed.current = false;
     // Limpar o canvas
     const canvas = maskCanvasRef.current;
     if (canvas) {
@@ -220,7 +222,7 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
     if (!container) return;
 
     const handleMove = (e: MouseEvent) => {
-      if (!isEncoded.current || isDecoding.current) return;
+      if (!isEncoded.current || isDecoding.current || selectionFixed.current) return;
       const point = getPoint(e);
       lastPoints.current = [point];
       isDecoding.current = true;


### PR DESCRIPTION
## Summary
- add FLUX inpainting pipeline and endpoint
- support hiding the description input in sidebar
- call new `/inpaint` API from object editing page
- keep selected mask fixed until reset

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687972cd7a688331905b7d41b4b96427