### PR TITLE
Fix multi-object selection and add inpaint prompt

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -250,13 +250,13 @@ def process_image(image: Image.Image, style_selection: str) -> Image.Image:
     return result
 
 
-def inpaint_image(image: Image.Image, mask: Image.Image) -> Image.Image:
+def inpaint_image(image: Image.Image, mask: Image.Image, prompt: str) -> Image.Image:
     size = (768, 768)
     image_resized = image.convert("RGB").resize(size)
     mask_resized = mask.convert("RGB").resize(size)
     generator = torch.Generator(device="cuda").manual_seed(random.randint(0, MAX_SEED))
     result = inpaint_pipe(
-        prompt="",
+        prompt=prompt,
         height=size[1],
         width=size[0],
         control_image=image_resized,
@@ -307,11 +307,12 @@ def change_style():
 def flux_inpaint():
     file = request.files.get("image")
     mask_file = request.files.get("mask")
+    prompt = request.form.get("prompt", "")
     if file is None or mask_file is None:
         return jsonify({"error": "image and mask required"}), 400
     img = Image.open(file.stream).convert("RGB")
     mask = Image.open(mask_file.stream).convert("RGB")
-    result = inpaint_image(img, mask)
+    result = inpaint_image(img, mask, prompt)
     buf = io.BytesIO()
     result.save(buf, format="PNG")
     buf.seek(0)

--- a/src/components/ObjectSelector.tsx
+++ b/src/components/ObjectSelector.tsx
@@ -19,7 +19,6 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
   const isEncoded = useRef(false);
   const isDecoding = useRef(false);
   const lastPoints = useRef<{ point: [number, number]; label: number }[]>([]);
-  const selectionFixed = useRef(false);
   const [selectedMasks, setSelectedMasks] = useState<any[]>([]);
   const [currentMask, setCurrentMask] = useState<{mask: any, scores: number[]} | null>(null);
   const [modelReady, setModelReady] = useState(false);
@@ -173,13 +172,11 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
       if (scores[i] > scores[bestIndex]) bestIndex = i;
     }
     setSelectedMasks(prev => [...prev, { mask, scores, numMasks, bestIndex }]);
-    selectionFixed.current = true;
   };
 
   const resetSelections = () => {
     setSelectedMasks([]);
     setCurrentMask(null);
-    selectionFixed.current = false;
     // Limpar o canvas
     const canvas = maskCanvasRef.current;
     if (canvas) {
@@ -222,7 +219,7 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
     if (!container) return;
 
     const handleMove = (e: MouseEvent) => {
-      if (!isEncoded.current || isDecoding.current || selectionFixed.current) return;
+      if (!isEncoded.current || isDecoding.current) return;
       const point = getPoint(e);
       lastPoints.current = [point];
       isDecoding.current = true;

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -8,6 +8,7 @@ import useGenerations from "@/hooks/useGenerations";
 const ChangeObjects = () => {
   const [image, setImage] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [prompt, setPrompt] = useState("");
 
   const selectorRef = useRef<ObjectSelectorHandle>(null);
   const { addGeneration } = useGenerations();
@@ -34,6 +35,7 @@ const ChangeObjects = () => {
       const form = new FormData();
       form.append('image', imageBlob, 'image.png');
       form.append('mask', maskBlob, 'mask.png');
+      form.append('prompt', prompt);
       const res = await fetch('/inpaint', { method: 'POST', body: form });
       if (!res.ok) throw new Error('failed');
       const outBlob = await res.blob();
@@ -73,7 +75,8 @@ const ChangeObjects = () => {
         </div>
 
         <DescriptionSidebar
-          hideDescription
+          description={prompt}
+          onDescriptionChange={setPrompt}
           onGenerate={handleGenerate}
           disableGenerate={loading}
           className="mr-6 mt-2 self-start flex-none"


### PR DESCRIPTION
## Summary
- allow selecting multiple objects again by removing selection freeze logic
- add an inpaint prompt field in **Alterar objetos** page
- send prompt to backend when inpainting
- support prompt in `/inpaint` endpoint

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `python3 -m py_compile server/app.py`


------
https://chatgpt.com/codex/tasks/task_b_687a861c3eb48331a31bbcfb53b82479