### PR TITLE
Fix preview update after inpainting

### DIFF
--- a/src/components/ObjectSelector.tsx
+++ b/src/components/ObjectSelector.tsx
@@ -8,6 +8,7 @@ interface ObjectSelectorProps {
 
 export interface ObjectSelectorHandle {
   exportMask: () => string | null;
+  resetSelections: () => void;
 }
 
 const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ image }, ref) => {
@@ -218,7 +219,7 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
     return canvas.toDataURL('image/png');
   };
 
-  useImperativeHandle(ref, () => ({ exportMask }), [selectedMasks]);
+  useImperativeHandle(ref, () => ({ exportMask, resetSelections }), [selectedMasks]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/src/hooks/useGenerations.ts
+++ b/src/hooks/useGenerations.ts
@@ -8,33 +8,52 @@ export interface Generation {
 
 const STORAGE_KEY = 'generations';
 
+// Mantém gerações em memória para sincronizar entre instâncias do hook
+let globalGenerations: Generation[] | null = null;
+const listeners = new Set<(items: Generation[]) => void>();
+
+const loadGenerations = (): Generation[] => {
+  if (globalGenerations) return globalGenerations;
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      globalGenerations = JSON.parse(stored);
+    } else {
+      globalGenerations = [];
+    }
+  } catch {
+    globalGenerations = [];
+  }
+  return globalGenerations;
+};
+
+const saveGenerations = (items: Generation[]) => {
+  globalGenerations = items;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // ignore write errors
+  }
+  listeners.forEach(l => l(items));
+};
+
 export default function useGenerations() {
-  const [generations, setGenerations] = useState<Generation[]>([]);
+  const [generations, setGenerations] = useState<Generation[]>(() => loadGenerations());
 
   useEffect(() => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        setGenerations(JSON.parse(stored));
-      }
-    } catch {
-      // ignore parse errors
-    }
+    const listener = (items: Generation[]) => setGenerations(items);
+    listeners.add(listener);
+    // garantir estado inicial
+    setGenerations(loadGenerations());
+    return () => {
+      listeners.delete(listener);
+    };
   }, []);
-
-  const save = (items: Generation[]) => {
-    setGenerations(items);
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
-    } catch {
-      // ignore write errors
-    }
-  };
 
   const addGeneration = (image: string) => {
     const gen: Generation = { id: Date.now().toString(), image, date: new Date().toISOString() };
-    const updated = [gen, ...generations];
-    save(updated);
+    const updated = [gen, ...loadGenerations()];
+    saveGenerations(updated);
   };
 
   return {

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -7,6 +7,7 @@ import useGenerations from "@/hooks/useGenerations";
 
 const ChangeObjects = () => {
   const [image, setImage] = useState<string | null>(null);
+  const [originalImage, setOriginalImage] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [prompt, setPrompt] = useState("");
 
@@ -15,6 +16,7 @@ const ChangeObjects = () => {
 
   const handleUpload = (dataUrl: string) => {
     setImage(dataUrl);
+    setOriginalImage(dataUrl);
   };
 
   async function blobToDataURL(blob: Blob): Promise<string> {
@@ -42,6 +44,7 @@ const ChangeObjects = () => {
       const dataUrl = await blobToDataURL(outBlob);
       setImage(dataUrl);
       addGeneration(dataUrl);
+      selectorRef.current?.resetSelections();
     } catch (err) {
       console.error('inpaint failed', err);
     } finally {
@@ -64,8 +67,12 @@ const ChangeObjects = () => {
           <div className="bg-card rounded-2xl overflow-hidden border border-border w-full max-w-5xl mx-auto">
             <UploadArea
               onImageSelected={handleUpload}
+              image={image}
               renderPreview={(img) => (
-                <div className="w-fit mx-auto relative">
+                <div className="w-fit mx-auto relative flex flex-col items-center gap-4">
+                  {originalImage && originalImage !== img && (
+                    <img src={originalImage} alt="Original" className="max-w-full rounded-lg" />
+                  )}
                   <ObjectSelector ref={selectorRef} image={img} />
                 </div>
               )}


### PR DESCRIPTION
## Summary
- expose `resetSelections` from `ObjectSelector`
- keep generations in a shared store via `useGenerations`
- show generated image over the original in ChangeObjects and reset masks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fcd83af9c8331adbc59bd4f5f6aa1