### PR TITLE
Enable replacing images from gallery

### DIFF
--- a/src/components/PreviousGenerations.tsx
+++ b/src/components/PreviousGenerations.tsx
@@ -3,7 +3,11 @@ import { Button } from "@/components/ui/button";
 import { useRef } from "react";
 import useGenerations from "@/hooks/useGenerations";
 
-const PreviousGenerations = () => {
+interface PreviousGenerationsProps {
+  onSelect?: (img: string) => void;
+}
+
+const PreviousGenerations = ({ onSelect }: PreviousGenerationsProps) => {
   const { generations } = useGenerations();
 
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -35,6 +39,11 @@ const PreviousGenerations = () => {
               <div
                 key={image.id}
                 className="flex-shrink-0 w-20 h-20 bg-muted rounded-lg overflow-hidden cursor-pointer hover:opacity-80 transition-opacity"
+                onDoubleClick={() => onSelect?.(image.image)}
+                draggable
+                onDragStart={e => {
+                  e.dataTransfer.setData('text/plain', image.image);
+                }}
               >
                 <img src={image.image} alt="geração" className="w-full h-full object-cover" />
               </div>

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -67,17 +67,15 @@ const ChangeObjects = () => {
           <div className="bg-card rounded-2xl overflow-hidden border border-border w-full max-w-5xl mx-auto">
             <UploadArea
               onImageSelected={handleUpload}
+              onRemoveImage={() => originalImage && setImage(originalImage)}
               image={image}
               renderPreview={(img) => (
                 <div className="w-fit mx-auto relative flex flex-col items-center gap-4">
-                  {originalImage && originalImage !== img && (
-                    <img src={originalImage} alt="Original" className="max-w-full rounded-lg" />
-                  )}
                   <ObjectSelector ref={selectorRef} image={img} />
                 </div>
               )}
             />
-            <PreviousGenerations />
+            <PreviousGenerations onSelect={(img) => { setImage(img); setOriginalImage(img); }} />
           </div>
         </div>
 

--- a/src/pages/ChangeStyle.tsx
+++ b/src/pages/ChangeStyle.tsx
@@ -56,7 +56,7 @@ const ChangeStyle = () => {
         <div className="flex-1 flex flex-col px-2 pt-2 pb-8">
           <div className="bg-card rounded-2xl overflow-hidden border border-border w-full max-w-5xl mx-auto">
             <UploadArea onImageSelected={handleUpload} image={image} />
-            <PreviousGenerations />
+            <PreviousGenerations onSelect={(img) => setImage(img)} />
           </div>
         </div>
 

--- a/src/pages/ChatEdit.tsx
+++ b/src/pages/ChatEdit.tsx
@@ -57,7 +57,7 @@ const ChatEdit = () => {
         <div className="flex-1 flex flex-col px-2 pt-2 pb-8">
           <div className="bg-card rounded-2xl overflow-hidden border border-border w-full max-w-5xl mx-auto">
             <UploadArea onImageSelected={handleUpload} image={image} />
-            <PreviousGenerations />
+            <PreviousGenerations onSelect={(img) => setImage(img)} />
           </div>
         </div>
 

--- a/src/pages/EmptyRoom.tsx
+++ b/src/pages/EmptyRoom.tsx
@@ -141,7 +141,11 @@ const EmptyRoom = () => {
                 </div>
               )}
             />
-            <PreviousGenerations />
+            <PreviousGenerations onSelect={(img) => {
+              setImage(img);
+              setSegData(null);
+              setObjects([]);
+            }} />
           </div>
         </div>
         <SettingsSidebar


### PR DESCRIPTION
## Summary
- allow removing current preview to revert to original image
- support drag-and-drop or double-click from previous generations
- expose gallery selection callback
- update pages to handle selection from gallery

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687fd03b7f6c83319cfe9a6763fd8267