### PR TITLE
Add prompt translation and generating overlay

### DIFF
--- a/src/components/UploadArea.tsx
+++ b/src/components/UploadArea.tsx
@@ -7,11 +7,23 @@ interface UploadAreaProps {
   onRemoveImage?: () => void;
   renderPreview?: (img: string) => React.ReactNode;
   image?: string | null;
+  loading?: boolean;
 }
 
-const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image }: UploadAreaProps) => {
+const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, loading = false }: UploadAreaProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<string | null>(image ?? null);
+  const [elapsed, setElapsed] = useState(0);
+
+  useEffect(() => {
+    if (!loading) {
+      setElapsed(0);
+      return;
+    }
+    setElapsed(0);
+    const id = setInterval(() => setElapsed(e => e + 1), 1000);
+    return () => clearInterval(id);
+  }, [loading]);
 
   // keep preview in sync when parent controls the image
   useEffect(() => {
@@ -95,6 +107,13 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image }: Up
             onDrop={handleDrop}
             onDragOver={handleDragOver}
           >
+            {preview && loading && (
+              <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-black/40 backdrop-blur-sm text-white">
+                <img src="/src/components/logo.svg" className="w-16 h-16 wobble mb-2" alt="logo" />
+                <p>Aguarde, sua imagem está sendo gerada</p>
+                <p className="text-blue-500 mt-1">{elapsed}s</p>
+              </div>
+            )}
             {/* Remove button */}
             {preview && (
               <Button
@@ -111,7 +130,7 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image }: Up
             )}
 
             {/* Inner content: prompt or preview */}
-            <div className="flex flex-col items-center justify-center h-full p-4 space-y-4">
+            <div className={`flex flex-col items-center justify-center h-full p-4 space-y-4 ${loading && preview ? 'filter blur-sm' : ''}`}>
               {!preview && (
                 <>
                   <h3 className="text-base font-medium text-foreground">

--- a/src/index.css
+++ b/src/index.css
@@ -111,3 +111,12 @@ All colors MUST be HSL.
     @apply bg-background text-foreground;
   }
 }
+}
+
+@keyframes wobble {
+ 0%,100% { transform: rotate(-5deg); }
+ 50% { transform: rotate(5deg); }
+}
+.wobble {
+  animation: wobble 3s ease-in-out infinite;
+}

--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -1,0 +1,17 @@
+export async function translateToEnglish(text: string): Promise<string> {
+  if (!text.trim()) return text;
+  try {
+    const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=en&dt=t&q=${encodeURIComponent(text)}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('Translation request failed');
+    const data = await res.json();
+    if (Array.isArray(data) && Array.isArray(data[0])) {
+      return data[0].map((p: any) => p[0]).join('');
+    }
+  } catch (err) {
+    console.error('translateToEnglish error', err);
+  }
+  return text;
+}
+
+export default translateToEnglish;

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -3,6 +3,7 @@ import PreviousGenerations from "@/components/PreviousGenerations";
 import ObjectSelector, { ObjectSelectorHandle } from "@/components/ObjectSelector";
 import DescriptionSidebar from "@/components/DescriptionSidebar";
 import { useState, useRef } from "react";
+import translateToEnglish from "@/lib/translate";
 import useGenerations from "@/hooks/useGenerations";
 
 const ChangeObjects = () => {
@@ -37,7 +38,8 @@ const ChangeObjects = () => {
       const form = new FormData();
       form.append('image', imageBlob, 'image.png');
       form.append('mask', maskBlob, 'mask.png');
-      form.append('prompt', prompt);
+      const translated = await translateToEnglish(prompt);
+      form.append('prompt', translated);
       const res = await fetch('/inpaint', { method: 'POST', body: form });
       if (!res.ok) throw new Error('failed');
       const outBlob = await res.blob();
@@ -69,6 +71,7 @@ const ChangeObjects = () => {
               onImageSelected={handleUpload}
               onRemoveImage={() => originalImage && setImage(originalImage)}
               image={image}
+              loading={loading}
               renderPreview={(img) => (
                 <div className="w-fit mx-auto relative flex flex-col items-center gap-4">
                   <ObjectSelector ref={selectorRef} image={img} />

--- a/src/pages/ChangeStyle.tsx
+++ b/src/pages/ChangeStyle.tsx
@@ -55,7 +55,7 @@ const ChangeStyle = () => {
       <div className="flex flex-1 items-start overflow-auto">
         <div className="flex-1 flex flex-col px-2 pt-2 pb-8">
           <div className="bg-card rounded-2xl overflow-hidden border border-border w-full max-w-5xl mx-auto">
-            <UploadArea onImageSelected={handleUpload} image={image} />
+            <UploadArea onImageSelected={handleUpload} image={image} loading={loading} />
             <PreviousGenerations onSelect={(img) => setImage(img)} />
           </div>
         </div>

--- a/src/pages/ChatEdit.tsx
+++ b/src/pages/ChatEdit.tsx
@@ -2,6 +2,7 @@ import UploadArea from "@/components/UploadArea";
 import PreviousGenerations from "@/components/PreviousGenerations";
 import DescriptionSidebar from "@/components/DescriptionSidebar";
 import { useState } from "react";
+import translateToEnglish from "@/lib/translate";
 import useGenerations from "@/hooks/useGenerations";
 
 async function blobToDataURL(blob: Blob): Promise<string> {
@@ -29,7 +30,8 @@ const ChatEdit = () => {
       const blob = await fetch(image).then(r => r.blob());
       const form = new FormData();
       form.append("image", blob, "image.png");
-      form.append("prompt", description);
+      const translated = await translateToEnglish(description);
+      form.append("prompt", translated);
       const res = await fetch("/flux-edit", { method: "POST", body: form });
       if (!res.ok) throw new Error("Failed to generate");
       const outBlob = await res.blob();
@@ -56,7 +58,7 @@ const ChatEdit = () => {
       <div className="flex flex-1 items-start overflow-auto">
         <div className="flex-1 flex flex-col px-2 pt-2 pb-8">
           <div className="bg-card rounded-2xl overflow-hidden border border-border w-full max-w-5xl mx-auto">
-            <UploadArea onImageSelected={handleUpload} image={image} />
+            <UploadArea onImageSelected={handleUpload} image={image} loading={loading} />
             <PreviousGenerations onSelect={(img) => setImage(img)} />
           </div>
         </div>


### PR DESCRIPTION
## Summary
- translate text prompts to English before sending to the backend
- show wobbling logo and timer while generating images
- add `translateToEnglish` utility
- apply blur and overlay in `UploadArea`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687fd905de6483318243709e694767cc