### PR TITLE
Fix CSS syntax error

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -111,7 +111,6 @@ All colors MUST be HSL.
     @apply bg-background text-foreground;
   }
 }
-}
 
 @keyframes wobble {
  0%,100% { transform: rotate(-5deg); }


### PR DESCRIPTION
## Summary
- remove unmatched closing brace in `src/index.css`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_687fdb36505483318b61f18b000a6504