### PR TITLE
Add mask editing modes with brush tool

### DIFF
--- a/src/components/BrushSelector.tsx
+++ b/src/components/BrushSelector.tsx
@@ -1,0 +1,167 @@
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { Undo2, Redo2, Brush, Eraser, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+
+export interface BrushSelectorHandle {
+  exportMask: () => string | null;
+  resetSelections: () => void;
+}
+
+interface BrushSelectorProps {
+  image: string | null;
+}
+
+const BrushSelector = forwardRef<BrushSelectorHandle, BrushSelectorProps>(({ image }, ref) => {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [brushSize, setBrushSize] = useState(20);
+  const [tool, setTool] = useState<'brush' | 'erase'>('brush');
+  const drawing = useRef(false);
+  const last = useRef<{x: number, y: number} | null>(null);
+  const undoStack = useRef<ImageData[]>([]);
+  const redoStack = useRef<ImageData[]>([]);
+
+  useImperativeHandle(ref, () => ({
+    exportMask: () => {
+      const canvas = canvasRef.current;
+      if (!canvas) return null;
+      return canvas.toDataURL('image/png');
+    },
+    resetSelections: () => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d')!;
+      ctx.clearRect(0,0,canvas.width,canvas.height);
+      undoStack.current = [];
+      redoStack.current = [];
+    }
+  }), []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const imgEl = imgRef.current;
+    if (!canvas || !imgEl || !image) return;
+    const handleResize = () => {
+      canvas.width = imgEl.offsetWidth;
+      canvas.height = imgEl.offsetHeight;
+    };
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [image]);
+
+  const getPos = (e: MouseEvent) => {
+    const canvas = canvasRef.current!;
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: (e.clientX - rect.left) * (canvas.width / rect.width),
+      y: (e.clientY - rect.top) * (canvas.height / rect.height)
+    };
+  };
+
+  const pushState = () => {
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext('2d')!;
+    undoStack.current.push(ctx.getImageData(0,0,canvas.width,canvas.height));
+    redoStack.current = [];
+  };
+
+  const draw = (e: MouseEvent) => {
+    if (!drawing.current) return;
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext('2d')!;
+    const pos = getPos(e);
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.lineWidth = brushSize;
+    if (tool === 'erase') {
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.strokeStyle = 'rgba(0,0,0,1)';
+    } else {
+      ctx.globalCompositeOperation = 'source-over';
+      ctx.strokeStyle = 'white';
+    }
+    ctx.beginPath();
+    if (last.current) {
+      ctx.moveTo(last.current.x, last.current.y);
+    } else {
+      ctx.moveTo(pos.x, pos.y);
+    }
+    ctx.lineTo(pos.x, pos.y);
+    ctx.stroke();
+    last.current = pos;
+  };
+
+  const handleDown = (e: MouseEvent) => {
+    if (!canvasRef.current) return;
+    pushState();
+    drawing.current = true;
+    last.current = getPos(e);
+    draw(e);
+  };
+
+  const handleUp = () => {
+    drawing.current = false;
+    last.current = null;
+  };
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.addEventListener('mousedown', handleDown as any);
+    canvas.addEventListener('mousemove', draw as any);
+    window.addEventListener('mouseup', handleUp);
+    return () => {
+      canvas.removeEventListener('mousedown', handleDown as any);
+      canvas.removeEventListener('mousemove', draw as any);
+      window.removeEventListener('mouseup', handleUp);
+    };
+  }, [brushSize, tool]);
+
+  const undo = () => {
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext('2d')!;
+    if (undoStack.current.length === 0) return;
+    redoStack.current.push(ctx.getImageData(0,0,canvas.width,canvas.height));
+    const img = undoStack.current.pop()!;
+    ctx.putImageData(img,0,0);
+  };
+
+  const redo = () => {
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext('2d')!;
+    if (redoStack.current.length === 0) return;
+    undoStack.current.push(ctx.getImageData(0,0,canvas.width,canvas.height));
+    const img = redoStack.current.pop()!;
+    ctx.putImageData(img,0,0);
+  };
+
+  const clear = () => {
+    const canvas = canvasRef.current!;
+    const ctx = canvas.getContext('2d')!;
+    ctx.clearRect(0,0,canvas.width,canvas.height);
+    undoStack.current = [];
+    redoStack.current = [];
+  };
+
+  return (
+    <div className="relative inline-block">
+      {image && <img ref={imgRef} src={image} alt="imagem" className="block" />}
+      <canvas ref={canvasRef} className="absolute inset-0" />
+
+      {/* toolbar */}
+      <div className="absolute bottom-2 left-2 flex items-center space-x-2 bg-background/80 p-1 rounded">
+        <Button size="icon" variant="ghost" onClick={undo}><Undo2 className="w-4 h-4" /></Button>
+        <Button size="icon" variant="ghost" onClick={redo}><Redo2 className="w-4 h-4" /></Button>
+        <Button size="icon" variant={tool==='brush'? 'default':'ghost'} onClick={()=>setTool('brush')}><Brush className="w-4 h-4" /></Button>
+        <Button size="icon" variant={tool==='erase'? 'default':'ghost'} onClick={()=>setTool('erase')}><Eraser className="w-4 h-4" /></Button>
+        <Button size="icon" variant="ghost" onClick={clear}><Trash2 className="w-4 h-4" /></Button>
+        <div className="w-24 ml-2"><Slider value={[brushSize]} min={1} max={100} onValueChange={(v)=>setBrushSize(v[0])} /></div>
+      </div>
+    </div>
+  );
+});
+
+export default BrushSelector;
+

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -1,0 +1,27 @@
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+interface ModeSelectorProps {
+  mode: string;
+  onModeChange: (mode: string) => void;
+  className?: string;
+}
+
+const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
+  return (
+    <ToggleGroup
+      type="single"
+      value={mode}
+      onValueChange={(v) => v && onModeChange(v)}
+      className={className}
+      variant="outline"
+      size="sm"
+    >
+      <ToggleGroupItem value="texto">Texto</ToggleGroupItem>
+      <ToggleGroupItem value="inteligente">Seleção Inteligente</ToggleGroupItem>
+      <ToggleGroupItem value="pincel">Pincel</ToggleGroupItem>
+      <ToggleGroupItem value="laco">Laço</ToggleGroupItem>
+    </ToggleGroup>
+  );
+};
+
+export default ModeSelector;

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -1,6 +1,8 @@
 import UploadArea from "@/components/UploadArea";
 import PreviousGenerations from "@/components/PreviousGenerations";
 import ObjectSelector, { ObjectSelectorHandle } from "@/components/ObjectSelector";
+import BrushSelector, { BrushSelectorHandle } from "@/components/BrushSelector";
+import ModeSelector from "@/components/ModeSelector";
 import DescriptionSidebar from "@/components/DescriptionSidebar";
 import { useState, useRef } from "react";
 import translateToEnglish from "@/lib/translate";
@@ -11,8 +13,10 @@ const ChangeObjects = () => {
   const [originalImage, setOriginalImage] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [prompt, setPrompt] = useState("");
+  const [mode, setMode] = useState("texto");
 
   const selectorRef = useRef<ObjectSelectorHandle>(null);
+  const brushRef = useRef<BrushSelectorHandle>(null);
   const { addGeneration } = useGenerations();
 
   const handleUpload = (dataUrl: string) => {
@@ -29,7 +33,9 @@ const ChangeObjects = () => {
   }
 
   const handleGenerate = async () => {
-    const maskData = selectorRef.current?.exportMask();
+    let maskData: string | null = null;
+    if (mode === 'inteligente') maskData = selectorRef.current?.exportMask() ?? null;
+    else if (mode === 'pincel') maskData = brushRef.current?.exportMask() ?? null;
     if (!maskData || !image) return;
     setLoading(true);
     try {
@@ -47,6 +53,7 @@ const ChangeObjects = () => {
       setImage(dataUrl);
       addGeneration(dataUrl);
       selectorRef.current?.resetSelections();
+      brushRef.current?.resetSelections();
     } catch (err) {
       console.error('inpaint failed', err);
     } finally {
@@ -74,7 +81,16 @@ const ChangeObjects = () => {
               loading={loading}
               renderPreview={(img) => (
                 <div className="w-fit mx-auto relative flex flex-col items-center gap-4">
-                  <ObjectSelector ref={selectorRef} image={img} />
+                  {mode === 'inteligente' && (
+                    <ObjectSelector ref={selectorRef} image={img} />
+                  )}
+                  {mode === 'pincel' && (
+                    <BrushSelector ref={brushRef} image={img} />
+                  )}
+                  {(mode === 'texto' || mode === 'laco') && (
+                    <img src={img} alt="pré" className="block" />
+                  )}
+                  <ModeSelector mode={mode} onModeChange={setMode} className="absolute top-2 left-2" />
                 </div>
               )}
             />


### PR DESCRIPTION
## Summary
- implement segmented control `ModeSelector` for selecting mask mode
- add `BrushSelector` component with brush and eraser, undo/redo, clear and brush size controls
- integrate new modes in `ChangeObjects` page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build:dev` *(fails: vite not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_b_687fdf8bfadc833185fc1e22525d0144