### PR TITLE
Improve brush opacity and button group style

### DIFF
--- a/src/components/BrushSelector.tsx
+++ b/src/components/BrushSelector.tsx
@@ -101,7 +101,7 @@ const BrushSelector = forwardRef<BrushSelectorHandle, BrushSelectorProps>(({ ima
       ctx.strokeStyle = 'rgba(0,0,0,1)';
     } else {
       ctx.globalCompositeOperation = 'source-over';
-      ctx.strokeStyle = 'rgba(128,0,128,0.5)';
+      ctx.strokeStyle = '#800080';
     }
     ctx.beginPath();
     if (last.current) {
@@ -191,7 +191,7 @@ const BrushSelector = forwardRef<BrushSelectorHandle, BrushSelectorProps>(({ ima
     <div className="inline-block">
       <div className="relative inline-block">
         {image && <img ref={imgRef} src={image} alt="imagem" className="block" />}
-        <canvas ref={canvasRef} className="absolute inset-0" />
+        <canvas ref={canvasRef} className="absolute inset-0 opacity-50" />
         <div ref={previewRef} className="absolute pointer-events-none rounded-full hidden" />
       </div>
       {/* toolbar below image */}

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 
 interface ModeSelectorProps {
@@ -7,20 +8,42 @@ interface ModeSelectorProps {
 }
 
 const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
+  const groupRef = useRef<HTMLDivElement>(null);
+  const indicatorRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const group = groupRef.current;
+    const indicator = indicatorRef.current;
+    if (!group || !indicator) return;
+    const active = group.querySelector('[data-state="on"]') as HTMLElement | null;
+    if (!active) return;
+    indicator.style.width = `${active.offsetWidth}px`;
+    indicator.style.transform = `translateX(${active.offsetLeft}px)`;
+  }, [mode]);
+
   return (
-    <ToggleGroup
-      type="single"
-      value={mode}
-      onValueChange={(v) => v && onModeChange(v)}
-      className={`bg-background/80 p-1 rounded-full shadow gap-1 ${className || ''}`}
-      variant="default"
-      size="sm"
+    <div
+      className={`relative inline-flex border border-border rounded-full ${className || ''}`}
     >
-      <ToggleGroupItem className="rounded-full px-4" value="texto">Texto</ToggleGroupItem>
-      <ToggleGroupItem className="rounded-full px-4" value="inteligente">Seleção Inteligente</ToggleGroupItem>
-      <ToggleGroupItem className="rounded-full px-4" value="pincel">Pincel</ToggleGroupItem>
-      <ToggleGroupItem className="rounded-full px-4" value="laco">Laço</ToggleGroupItem>
-    </ToggleGroup>
+      <span
+        ref={indicatorRef}
+        className="absolute left-0 top-0 h-full rounded-full bg-muted transition-all duration-300"
+      />
+      <ToggleGroup
+        ref={groupRef}
+        type="single"
+        value={mode}
+        onValueChange={(v) => v && onModeChange(v)}
+        className="relative p-1 gap-1"
+        variant="default"
+        size="sm"
+      >
+        <ToggleGroupItem className="rounded-full px-4 transition-colors" value="texto">Texto</ToggleGroupItem>
+        <ToggleGroupItem className="rounded-full px-4 transition-colors" value="inteligente">Seleção Inteligente</ToggleGroupItem>
+        <ToggleGroupItem className="rounded-full px-4 transition-colors" value="pincel">Pincel</ToggleGroupItem>
+        <ToggleGroupItem className="rounded-full px-4 transition-colors" value="laco">Laço</ToggleGroupItem>
+      </ToggleGroup>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- keep brush color consistent instead of layering darker strokes
- show brush canvas with constant opacity
- redesign mode selector group with transparent background
- add animated indicator when switching modes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_68800046a19083319135642ff03c8254