### PR TITLE
Adjust tool UI spacing and colors

### DIFF
--- a/src/components/BrushSelector.tsx
+++ b/src/components/BrushSelector.tsx
@@ -77,10 +77,19 @@ const BrushSelector = forwardRef<BrushSelectorHandle, BrushSelectorProps>(({ ima
     preview.style.height = `${brushSize}px`;
     preview.style.left = `${pos.x - brushSize / 2}px`;
     preview.style.top = `${pos.y - brushSize / 2}px`;
+    const ring = getComputedStyle(document.documentElement)
+      .getPropertyValue('--sidebar-ring')
+      .trim();
     preview.style.background =
-      tool === 'erase' ? 'rgba(0,0,0,0.2)' : 'rgba(128,0,128,0.2)';
+      tool === 'erase'
+        ? 'rgba(0,0,0,0.2)'
+        : `hsla(${ring} / 0.2)`;
     preview.style.border =
-      tool === 'erase' ? '1px solid red' : '1px solid rgba(128,0,128,0.8)';
+      tool === 'erase'
+        ? '1px solid red'
+        : `1px solid hsla(${ring} / 0.8)`;
+    preview.style.color =
+      tool === 'erase' ? 'red' : `hsl(${ring})`;
   };
 
   const hidePreview = () => {
@@ -101,7 +110,10 @@ const BrushSelector = forwardRef<BrushSelectorHandle, BrushSelectorProps>(({ ima
       ctx.strokeStyle = 'rgba(0,0,0,1)';
     } else {
       ctx.globalCompositeOperation = 'source-over';
-      ctx.strokeStyle = '#800080';
+      const ring = getComputedStyle(document.documentElement)
+        .getPropertyValue('--sidebar-ring')
+        .trim();
+      ctx.strokeStyle = `hsl(${ring})`;
     }
     ctx.beginPath();
     if (last.current) {
@@ -192,7 +204,12 @@ const BrushSelector = forwardRef<BrushSelectorHandle, BrushSelectorProps>(({ ima
       <div className="relative inline-block">
         {image && <img ref={imgRef} src={image} alt="imagem" className="block" />}
         <canvas ref={canvasRef} className="absolute inset-0 opacity-50" />
-        <div ref={previewRef} className="absolute pointer-events-none rounded-full hidden" />
+        <div
+          ref={previewRef}
+          className="absolute pointer-events-none rounded-full hidden flex items-center justify-center select-none"
+        >
+          <span className="text-xs text-[hsl(var(--sidebar-ring))]">+</span>
+        </div>
       </div>
       {/* toolbar below image */}
       <div className="mt-2 flex items-center space-x-2 bg-background/80 p-1 rounded">

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -27,7 +27,8 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
     >
       <span
         ref={indicatorRef}
-        className="absolute left-0 top-0 h-full rounded-full bg-muted transition-all duration-300"
+        className="absolute left-0 top-0 h-full rounded-full transition-all duration-300"
+        style={{ backgroundColor: 'hsl(var(--sidebar-ring) / 0.2)' }}
       />
       <ToggleGroup
         ref={groupRef}
@@ -38,10 +39,30 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
         variant="default"
         size="sm"
       >
-        <ToggleGroupItem className="rounded-full px-4 transition-colors" value="texto">Texto</ToggleGroupItem>
-        <ToggleGroupItem className="rounded-full px-4 transition-colors" value="inteligente">Seleção Inteligente</ToggleGroupItem>
-        <ToggleGroupItem className="rounded-full px-4 transition-colors" value="pincel">Pincel</ToggleGroupItem>
-        <ToggleGroupItem className="rounded-full px-4 transition-colors" value="laco">Laço</ToggleGroupItem>
+        <ToggleGroupItem
+          className="rounded-full px-4 transition-colors data-[state=on]:bg-transparent data-[state=on]:text-foreground"
+          value="texto"
+        >
+          Texto
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          className="rounded-full px-4 transition-colors data-[state=on]:bg-transparent data-[state=on]:text-foreground"
+          value="inteligente"
+        >
+          Seleção Inteligente
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          className="rounded-full px-4 transition-colors data-[state=on]:bg-transparent data-[state=on]:text-foreground"
+          value="pincel"
+        >
+          Pincel
+        </ToggleGroupItem>
+        <ToggleGroupItem
+          className="rounded-full px-4 transition-colors data-[state=on]:bg-transparent data-[state=on]:text-foreground"
+          value="laco"
+        >
+          Laço
+        </ToggleGroupItem>
       </ToggleGroup>
     </div>
   );

--- a/src/components/UploadArea.tsx
+++ b/src/components/UploadArea.tsx
@@ -81,11 +81,11 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, load
   };
 
   return (
-    <div className="p-8">
+    <div className="px-8 pt-4 pb-8">
       <div className="max-w-5xl mx-auto">
         {/* Main heading */}
         {!preview && (
-          <div className="text-center mb-4">
+          <div className="text-center mb-3">
             <div className="flex items-center justify-center mb-2 space-x-2">
               <div className="inline-flex items-center justify-center w-6 h-6 bg-primary/10 rounded-full">
                 <span className="text-sm">1</span>

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -95,7 +95,7 @@ const ChangeObjects = () => {
             <ModeSelector
               mode={mode}
               onModeChange={setMode}
-              className="mx-auto mt-4 mb-2 w-fit"
+              className="ml-4 mt-2 mb-1 w-fit"
             />
             <UploadArea
               onImageSelected={handleUpload}


### PR DESCRIPTION
## Summary
- tweak brush preview to use sidebar highlight color with `+` marker
- tone down ModeSelector highlight and use sidebar purple
- shift and tighten button spacing
- reduce padding above upload instructions
- match brush stroke color to highlight

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688002946560833181c20eec2609419c