### PR TITLE
Add fullscreen gallery to generations page

### DIFF
--- a/src/pages/Generations.tsx
+++ b/src/pages/Generations.tsx
@@ -1,10 +1,31 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+} from "@/components/ui/dialog";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+  type CarouselApi,
+} from "@/components/ui/carousel";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import useGenerations from "@/hooks/useGenerations";
 
 const Generations = () => {
   const { generations } = useGenerations();
   const [sortBy, setSortBy] = useState("newest");
+  const [open, setOpen] = useState(false);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [carouselApi, setCarouselApi] = useState<CarouselApi>();
+
+  useEffect(() => {
+    if (open && carouselApi) {
+      carouselApi.scrollTo(currentIndex);
+    }
+  }, [open, currentIndex, carouselApi]);
 
   const sortedGenerations = [...generations].sort((a, b) => {
     if (sortBy === "newest") {
@@ -42,10 +63,14 @@ const Generations = () => {
 
           {/* Gallery Grid */}
           <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-4">
-            {sortedGenerations.map(item => (
+            {sortedGenerations.map((item, index) => (
               <div
                 key={item.id}
                 className="relative aspect-square bg-gray-100 rounded-lg overflow-hidden hover:opacity-90 transition-opacity cursor-pointer"
+                onClick={() => {
+                  setCurrentIndex(index);
+                  setOpen(true);
+                }}
               >
                 <img
                   src={item.image}
@@ -55,6 +80,26 @@ const Generations = () => {
               </div>
             ))}
           </div>
+
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogContent className="max-w-5xl w-full p-0">
+              <Carousel opts={{ loop: true }} setApi={setCarouselApi} className="relative">
+                <CarouselContent>
+                  {sortedGenerations.map((item) => (
+                    <CarouselItem key={item.id} className="flex items-center justify-center">
+                      <img
+                        src={item.image}
+                        alt={`Generation ${item.id}`}
+                        className="max-h-[80vh] w-full object-contain"
+                      />
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
+                <CarouselPrevious className="left-2 top-1/2 -translate-y-1/2" />
+                <CarouselNext className="right-2 top-1/2 -translate-y-1/2" />
+              </Carousel>
+            </DialogContent>
+          </Dialog>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- enable a dialog based gallery on the Generations page
- allow navigating images with a carousel in fullscreen

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6881608e23c08331812f0b26218c540e