### PR TITLE
Improve masking and lasso visuals

### DIFF
--- a/src/components/BrushSelector.tsx
+++ b/src/components/BrushSelector.tsx
@@ -32,8 +32,14 @@ const BrushSelector = forwardRef<BrushSelectorHandle, BrushSelectorProps>(({ ima
   useImperativeHandle(ref, () => ({
     exportMask: () => {
       const canvas = canvasRef.current;
-      if (!canvas) return null;
-      return canvas.toDataURL('image/png');
+      const img = imgRef.current;
+      if (!canvas || !img) return null;
+      const out = document.createElement('canvas');
+      out.width = img.naturalWidth;
+      out.height = img.naturalHeight;
+      const ctx = out.getContext('2d')!;
+      ctx.drawImage(canvas, 0, 0, out.width, out.height);
+      return out.toDataURL('image/png');
     },
     resetSelections: () => {
       const canvas = canvasRef.current;

--- a/src/components/LassoSelector.tsx
+++ b/src/components/LassoSelector.tsx
@@ -106,10 +106,23 @@ const LassoSelector = forwardRef<LassoSelectorHandle, LassoSelectorProps>(({ ima
       canvas.height = img.offsetHeight;
       const ctx = canvas.getContext("2d")!;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.strokeStyle = "hsl(var(--sidebar-ring))";
-      ctx.fillStyle = "hsla(var(--sidebar-ring) / 0.3)";
+
+      const ring = getComputedStyle(document.documentElement)
+        .getPropertyValue("--sidebar-ring")
+        .trim();
+      const palette = [
+        ring,
+        "140 70% 45%",
+        "60 90% 50%",
+        "210 90% 55%",
+        "300 70% 60%",
+      ];
+
       ctx.lineWidth = 2;
-      polygons.forEach((poly) => {
+      polygons.forEach((poly, i) => {
+        const color = palette[i % palette.length];
+        ctx.strokeStyle = `hsl(${color})`;
+        ctx.fillStyle = `hsla(${color} / 0.3)`;
         ctx.beginPath();
         poly.points.forEach((pt, idx) => {
           const x = pt.x * canvas.width;
@@ -120,7 +133,10 @@ const LassoSelector = forwardRef<LassoSelectorHandle, LassoSelectorProps>(({ ima
         ctx.fill();
         ctx.stroke();
       });
+
       if (current.length > 0) {
+        const color = palette[polygons.length % palette.length];
+        ctx.strokeStyle = `hsl(${color})`;
         ctx.beginPath();
         current.forEach((pt, idx) => {
           const x = pt.x * canvas.width;

--- a/src/components/PreviousGenerations.tsx
+++ b/src/components/PreviousGenerations.tsx
@@ -21,9 +21,9 @@ const PreviousGenerations = ({ onSelect }: PreviousGenerationsProps) => {
   };
 
   return (
-    <div className="px-6 pb-6 pt-4">
+    <div className="px-6 pb-6 pt-2">
       <div className="w-full mx-4">
-        <h3 className="text-lg font-semibold text-foreground mb-4">Gerações anteriores</h3>
+        <h3 className="text-lg font-semibold text-foreground mb-2">Gerações anteriores</h3>
 
         <div className="relative">
           <Button

--- a/src/components/UploadArea.tsx
+++ b/src/components/UploadArea.tsx
@@ -81,7 +81,7 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, load
   };
 
   return (
-    <div className="px-8 pt-4 pb-8">
+    <div className="px-8 pt-2 pb-2">
       <div className="max-w-5xl mx-auto">
         {/* Main heading */}
         {!preview && (
@@ -119,7 +119,7 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, load
               <Button
                 variant="destructive"
                 size="sm"
-                className="absolute top-3 right-3 z-10 h-8 w-8 p-0"
+                className="absolute top-2 right-2 z-10 h-8 w-8 p-0"
                 onClick={e => {
                   e.stopPropagation();
                   handleRemoveImage();


### PR DESCRIPTION
## Summary
- fix mask export size in BrushSelector
- color cycle lasso layers
- tighten spacing in UploadArea and PreviousGenerations
- adjust remove button positioning

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688162c19d208331bbc37eca5414a65f