### PR TITLE
Update object edit layout

### DIFF
--- a/src/components/PreviousGenerations.tsx
+++ b/src/components/PreviousGenerations.tsx
@@ -21,7 +21,7 @@ const PreviousGenerations = ({ onSelect }: PreviousGenerationsProps) => {
   };
 
   return (
-    <div className="px-6 pb-6 pt-2">
+    <div className="px-6 pb-4 pt-1">
       <div className="w-full mx-4">
         <h3 className="text-lg font-semibold text-foreground mb-2">Gerações anteriores</h3>
 

--- a/src/components/UploadArea.tsx
+++ b/src/components/UploadArea.tsx
@@ -81,7 +81,7 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, load
   };
 
   return (
-    <div className="px-8 pt-2 pb-2">
+    <div className="px-8 pt-1 pb-2">
       <div className="max-w-5xl mx-auto">
         {/* Main heading */}
         {!preview && (
@@ -109,7 +109,7 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, load
           >
             {preview && loading && (
               <div className="absolute inset-0 z-20 flex flex-col items-center justify-center bg-black/40 backdrop-blur-sm text-white">
-                <img src="/src/components/logo.svg" className="w-16 h-16 tilt mb-2" alt="logo" />
+                <img src="/src/components/logo.svg" className="w-16 h-16 wobble mb-2" alt="logo" />
                 <p>Aguarde, sua imagem está sendo gerada</p>
                 <p className="text-blue-500 mt-1">{elapsed}s</p>
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -112,10 +112,12 @@ All colors MUST be HSL.
   }
 }
 
-@keyframes tilt {
-  0%,100% { transform: rotate(-2deg); }
-  50% { transform: rotate(2deg); }
+@keyframes wobble {
+  0%,100% { transform: rotate(-6deg); }
+  25% { transform: rotate(6deg); }
+  50% { transform: rotate(-6deg); }
+  75% { transform: rotate(6deg); }
 }
-.tilt {
-  animation: tilt 3s ease-in-out infinite;
+.wobble {
+  animation: wobble 1.5s ease-in-out infinite;
 }

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -136,7 +136,7 @@ const ChangeObjects = () => {
             <ModeSelector
               mode={mode}
               onModeChange={setMode}
-              className="ml-4 mt-2 mb-1 w-fit"
+              className="ml-4 mt-2 mb-0 w-fit"
             />
             <UploadArea
               onImageSelected={handleUpload}
@@ -147,21 +147,23 @@ const ChangeObjects = () => {
               loading={loading}
               renderPreview={(img) => (
                 <div className="w-fit mx-auto">
-                  <div className="relative" ref={previewRef}>
-                    {mode === 'inteligente' && (
-                      <ObjectSelector ref={selectorRef} image={img} />
-                    )}
-                    {mode === 'pincel' && (
-                      <BrushSelector ref={brushRef} image={img} />
-                    )}
-                    {mode === 'laco' && (
-                      <LassoSelector ref={lassoRef} image={img} />
-                    )}
-                    {mode === 'texto' && (
-                      <img src={img} alt="pré" className="block" />
-                    )}
+                  <div className="flex items-start" ref={previewRef}>
+                    <div className="relative">
+                      {mode === 'inteligente' && (
+                        <ObjectSelector ref={selectorRef} image={img} />
+                      )}
+                      {mode === 'pincel' && (
+                        <BrushSelector ref={brushRef} image={img} />
+                      )}
+                      {mode === 'laco' && (
+                        <LassoSelector ref={lassoRef} image={img} />
+                      )}
+                      {mode === 'texto' && (
+                        <img src={img} alt="pré" className="block" />
+                      )}
+                    </div>
                     <TooltipProvider>
-                      <div className="absolute bottom-2 right-2 flex flex-col space-y-2">
+                      <div className="flex flex-col space-y-2 ml-2 sticky top-2">
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Button size="icon" className="h-8 w-8 p-0" variant="secondary" onClick={handleSaveAs}>


### PR DESCRIPTION
## Summary
- tweak padding around image upload area
- switch tilt animation to wobble with stronger effect
- keep logo wobbling while generating
- reposition Save/Download/Fullscreen buttons beside the image
- reduce spacing around previous generations list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_6881659456a48331ae99be5ba421bdff