### PR TITLE
Adjust wobble animation and expand smart mask

### DIFF
--- a/src/components/ObjectSelector.tsx
+++ b/src/components/ObjectSelector.tsx
@@ -192,6 +192,32 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
     }
   };
 
+  const expandImageData = (imageData: ImageData): ImageData => {
+    const { width, height, data } = imageData;
+    const expanded = new Uint8ClampedArray(data.length);
+    const radius = Math.ceil(Math.max(width, height) * 0.025);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = (y * width + x) * 4;
+        if (data[idx + 3] > 0) {
+          for (let dy = -radius; dy <= radius; dy++) {
+            for (let dx = -radius; dx <= radius; dx++) {
+              const nx = x + dx;
+              const ny = y + dy;
+              if (nx < 0 || nx >= width || ny < 0 || ny >= height) continue;
+              const nidx = (ny * width + nx) * 4;
+              expanded[nidx] = 255;
+              expanded[nidx + 1] = 255;
+              expanded[nidx + 2] = 255;
+              expanded[nidx + 3] = 255;
+            }
+          }
+        }
+      }
+    }
+    return new ImageData(expanded, width, height);
+  };
+
   const exportMask = (): string | null => {
     if (selectedMasks.length === 0) return null;
     const width = selectedMasks[0].mask.width;
@@ -215,7 +241,8 @@ const ObjectSelector = forwardRef<ObjectSelectorHandle, ObjectSelectorProps>(({ 
         }
       }
     });
-    ctx.putImageData(imageData, 0, 0);
+    const expanded = expandImageData(imageData);
+    ctx.putImageData(expanded, 0, 0);
     return canvas.toDataURL('image/png');
   };
 

--- a/src/index.css
+++ b/src/index.css
@@ -113,11 +113,11 @@ All colors MUST be HSL.
 }
 
 @keyframes wobble {
-  0%,100% { transform: rotate(-6deg); }
-  25% { transform: rotate(6deg); }
-  50% { transform: rotate(-6deg); }
-  75% { transform: rotate(6deg); }
+  0%,100% { transform: rotate(-4deg); }
+  25% { transform: rotate(4deg); }
+  50% { transform: rotate(-4deg); }
+  75% { transform: rotate(4deg); }
 }
 .wobble {
-  animation: wobble 1.5s ease-in-out infinite;
+  animation: wobble 2s ease-in-out infinite;
 }

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -147,7 +147,7 @@ const ChangeObjects = () => {
               loading={loading}
               renderPreview={(img) => (
                 <div className="w-fit mx-auto">
-                  <div className="flex items-start" ref={previewRef}>
+                  <div className="flex items-center" ref={previewRef}>
                     <div className="relative">
                       {mode === 'inteligente' && (
                         <ObjectSelector ref={selectorRef} image={img} />
@@ -163,7 +163,7 @@ const ChangeObjects = () => {
                       )}
                     </div>
                     <TooltipProvider>
-                      <div className="flex flex-col space-y-2 ml-2 sticky top-2">
+                      <div className="flex flex-col space-y-2 ml-2 self-center">
                         <Tooltip>
                           <TooltipTrigger asChild>
                             <Button size="icon" className="h-8 w-8 p-0" variant="secondary" onClick={handleSaveAs}>


### PR DESCRIPTION
## Summary
- slow down the wobble animation and reduce the angle
- center the Save/Download/Fullscreen buttons on the preview image
- enlarge exported smart selection masks by about 10%

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688167af01208331b0eba920ce389b74