### PR TITLE
Implement FluxKontext in text mode

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -159,12 +159,12 @@ print(
 
 # Initialize Flux Kontext pipeline for chat-based edits
 print("loading Flux Kontext pipeline")
-#flux_pipe = FluxKontextPipeline.from_pretrained(
-#    "black-forest-labs/FLUX.1-Kontext-dev",
-#    torch_dtype=torch.bfloat16,
-#)
-#flux_pipe.to("cuda")
-#integrity_checker = PixtralContentFilter(torch.device("cuda"))
+flux_pipe = FluxKontextPipeline.from_pretrained(
+    "black-forest-labs/FLUX.1-Kontext-dev",
+    torch_dtype=torch.bfloat16,
+)
+flux_pipe.to("cuda")
+integrity_checker = PixtralContentFilter(torch.device("cuda"))
 
 # Initialize Flux Kontext inpainting pipeline
 check_min_version("0.30.2")


### PR DESCRIPTION
## Summary
- load `FluxKontextPipeline` on the server for text edits
- use `/flux-edit` when `texto` mode is selected on Change Objects page

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6882912617088331947985988a1330d7