### PR TITLE
Improve selection UI and brush export

### DIFF
--- a/src/components/BrushSelector.tsx
+++ b/src/components/BrushSelector.tsx
@@ -38,7 +38,26 @@ const BrushSelector = forwardRef<BrushSelectorHandle, BrushSelectorProps>(({ ima
       out.width = img.naturalWidth;
       out.height = img.naturalHeight;
       const ctx = out.getContext('2d')!;
+      // fill background black then draw the current mask scaled to the image size
+      ctx.fillStyle = 'black';
+      ctx.fillRect(0, 0, out.width, out.height);
       ctx.drawImage(canvas, 0, 0, out.width, out.height);
+      // convert non-transparent pixels to white to ensure a binary mask
+      const imgData = ctx.getImageData(0, 0, out.width, out.height);
+      for (let i = 0; i < imgData.data.length; i += 4) {
+        if (imgData.data[i + 3] > 0) {
+          imgData.data[i] = 255;
+          imgData.data[i + 1] = 255;
+          imgData.data[i + 2] = 255;
+          imgData.data[i + 3] = 255;
+        } else {
+          imgData.data[i] = 0;
+          imgData.data[i + 1] = 0;
+          imgData.data[i + 2] = 0;
+          imgData.data[i + 3] = 255;
+        }
+      }
+      ctx.putImageData(imgData, 0, 0);
       return out.toDataURL('image/png');
     },
     resetSelections: () => {

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -1,5 +1,11 @@
-import { useEffect, useRef } from "react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+import {
+  Type,
+  Sparkles,
+  Brush,
+  LassoSelect,
+} from "lucide-react";
 
 interface ModeSelectorProps {
   mode: string;
@@ -8,63 +14,28 @@ interface ModeSelectorProps {
 }
 
 const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
-  const groupRef = useRef<HTMLDivElement>(null);
-  const indicatorRef = useRef<HTMLSpanElement>(null);
-
-  useEffect(() => {
-    const group = groupRef.current;
-    const indicator = indicatorRef.current;
-    if (!group || !indicator) return;
-    const active = group.querySelector('[data-state="on"]') as HTMLElement | null;
-    if (!active) return;
-    indicator.style.width = `${active.offsetWidth}px`;
-    indicator.style.transform = `translateX(${active.offsetLeft}px)`;
-  }, [mode]);
-
   return (
-    <div
-      className={`relative inline-flex border border-border rounded-full ${className || ''}`}
+    <ToggleGroup
+      type="single"
+      value={mode}
+      onValueChange={(v) => v && onModeChange(v)}
+      className={cn("inline-flex gap-1 p-1 border border-border rounded-md bg-muted/60", className)}
+      variant="outline"
+      size="sm"
     >
-      <span
-        ref={indicatorRef}
-        className="absolute left-0 top-0 h-full rounded-full transition-all duration-300"
-        style={{ backgroundColor: 'hsl(var(--sidebar-ring) / 0.2)' }}
-      />
-      <ToggleGroup
-        ref={groupRef}
-        type="single"
-        value={mode}
-        onValueChange={(v) => v && onModeChange(v)}
-        className="relative p-1 gap-1"
-        variant="default"
-        size="sm"
-      >
-        <ToggleGroupItem
-          className="rounded-full px-4 transition-colors data-[state=on]:bg-transparent data-[state=on]:text-foreground"
-          value="texto"
-        >
-          Texto
-        </ToggleGroupItem>
-        <ToggleGroupItem
-          className="rounded-full px-4 transition-colors data-[state=on]:bg-transparent data-[state=on]:text-foreground"
-          value="inteligente"
-        >
-          Seleção Inteligente
-        </ToggleGroupItem>
-        <ToggleGroupItem
-          className="rounded-full px-4 transition-colors data-[state=on]:bg-transparent data-[state=on]:text-foreground"
-          value="pincel"
-        >
-          Pincel
-        </ToggleGroupItem>
-        <ToggleGroupItem
-          className="rounded-full px-4 transition-colors data-[state=on]:bg-transparent data-[state=on]:text-foreground"
-          value="laco"
-        >
-          Laço
-        </ToggleGroupItem>
-      </ToggleGroup>
-    </div>
+      <ToggleGroupItem value="texto" className="w-8 h-8 p-0">
+        <Type className="w-4 h-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="inteligente" className="w-8 h-8 p-0">
+        <Sparkles className="w-4 h-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="pincel" className="w-8 h-8 p-0">
+        <Brush className="w-4 h-4" />
+      </ToggleGroupItem>
+      <ToggleGroupItem value="laco" className="w-8 h-8 p-0">
+        <LassoSelect className="w-4 h-4" />
+      </ToggleGroupItem>
+    </ToggleGroup>
   );
 };
 


### PR DESCRIPTION
## Summary
- restyled the mode selector to use compact square icon buttons
- ensured brush mask exports a clean binary mask for inpainting

## Testing
- `npm run lint` *(fails: network access required to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68829647fc988331856f598b2d25d5f1