### PR TITLE
Add tooltips and styling for tool buttons

### DIFF
--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -1,4 +1,5 @@
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import {
   Type,
@@ -19,22 +20,57 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
       type="single"
       value={mode}
       onValueChange={(v) => v && onModeChange(v)}
-      className={cn("inline-flex gap-1 p-1 border border-border rounded-md bg-muted/60", className)}
-      variant="outline"
+      className={cn(
+        "inline-flex gap-1 p-1 border border-border rounded-md bg-gray-100",
+        className
+      )}
+      variant="default"
       size="sm"
     >
-      <ToggleGroupItem value="texto" className="w-8 h-8 p-0">
-        <Type className="w-4 h-4" />
-      </ToggleGroupItem>
-      <ToggleGroupItem value="inteligente" className="w-8 h-8 p-0">
-        <Sparkles className="w-4 h-4" />
-      </ToggleGroupItem>
-      <ToggleGroupItem value="pincel" className="w-8 h-8 p-0">
-        <Brush className="w-4 h-4" />
-      </ToggleGroupItem>
-      <ToggleGroupItem value="laco" className="w-8 h-8 p-0">
-        <LassoSelect className="w-4 h-4" />
-      </ToggleGroupItem>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ToggleGroupItem
+            value="texto"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-accent/70"
+          >
+            <Type className="w-4 h-4" />
+          </ToggleGroupItem>
+        </TooltipTrigger>
+        <TooltipContent>Texto</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ToggleGroupItem
+            value="inteligente"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-accent/70"
+          >
+            <Sparkles className="w-4 h-4" />
+          </ToggleGroupItem>
+        </TooltipTrigger>
+        <TooltipContent>Seleção inteligente</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ToggleGroupItem
+            value="pincel"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-accent/70"
+          >
+            <Brush className="w-4 h-4" />
+          </ToggleGroupItem>
+        </TooltipTrigger>
+        <TooltipContent>Pincel</TooltipContent>
+      </Tooltip>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <ToggleGroupItem
+            value="laco"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-accent/70"
+          >
+            <LassoSelect className="w-4 h-4" />
+          </ToggleGroupItem>
+        </TooltipTrigger>
+        <TooltipContent>Laço</TooltipContent>
+      </Tooltip>
     </ToggleGroup>
   );
 };


### PR DESCRIPTION
## Summary
- improve `ModeSelector` styling
- add Tooltip around each tool button

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68829925f0fc8331be2821494a920e4e