### PR TITLE
Remove chat edit tab and update mode selector

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,6 @@ import Projects from "./pages/Projects";
 import NotFound from "./pages/NotFound";
 import Academy from "./pages/Academy";
 import ChangeStyle from "./pages/ChangeStyle";
-import ChatEdit from "./pages/ChatEdit";
 import Profile, { ProfileOverview } from "./pages/Profile";
 import ProfilePersonalData from "./pages/ProfilePersonalData";
 import ProfileBilling from "./pages/ProfileBilling";
@@ -32,7 +31,6 @@ const App = () => (
             <Route index element={<Home />} />
             <Route path="empty-room" element={<EmptyRoom />} />
             <Route path="change-objects" element={<ChangeObjects />} />
-            <Route path="chat-edit" element={<ChatEdit />} />
             <Route path="change-style" element={<ChangeStyle />} />
             <Route path="improve-render" element={<Index />} />
             <Route path="generations" element={<Generations />} />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -36,8 +36,6 @@ const Header = () => {
     pageTitle = "Esvaziar cômodo";
   } else if (location.pathname === "/change-objects") {
     pageTitle = "Alterar objetos";
-  } else if (location.pathname === "/chat-edit") {
-    pageTitle = "Edição por Chat";
   } else if (location.pathname === "/change-style") {
     pageTitle = "Mudar Estilo";
   } else if (location.pathname === "/generations") {

--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -21,7 +21,7 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
       value={mode}
       onValueChange={(v) => v && onModeChange(v)}
       className={cn(
-        "inline-flex gap-1 p-1 border border-border rounded-md bg-gray-100",
+        "inline-flex gap-1 p-1 border border-border rounded-md bg-gray-50",
         className
       )}
       variant="default"
@@ -31,7 +31,7 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
         <TooltipTrigger asChild>
           <ToggleGroupItem
             value="texto"
-            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-accent/70"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary"
           >
             <Type className="w-4 h-4" />
           </ToggleGroupItem>
@@ -42,7 +42,7 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
         <TooltipTrigger asChild>
           <ToggleGroupItem
             value="inteligente"
-            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-accent/70"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary"
           >
             <Sparkles className="w-4 h-4" />
           </ToggleGroupItem>
@@ -53,7 +53,7 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
         <TooltipTrigger asChild>
           <ToggleGroupItem
             value="pincel"
-            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-accent/70"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary"
           >
             <Brush className="w-4 h-4" />
           </ToggleGroupItem>
@@ -64,7 +64,7 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
         <TooltipTrigger asChild>
           <ToggleGroupItem
             value="laco"
-            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-accent/70"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary"
           >
             <LassoSelect className="w-4 h-4" />
           </ToggleGroupItem>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 
-import { Armchair, PackagePlus, Home, Clock, HelpCircle, Grid3X3, BrushCleaning, RefreshCcwDot, MessageCircle } from "lucide-react";
+import { Armchair, PackagePlus, Home, Clock, HelpCircle, Grid3X3, BrushCleaning, RefreshCcwDot } from "lucide-react";
 import logo from "./logo.png";
 import nameLogo from "./name_logo.png";
 import { useState } from "react";
@@ -17,7 +17,6 @@ const Sidebar = () => {
     { divider: true },
     { icon: BrushCleaning, label: "Esvaziar Cômodo", path: "/empty-room" },
     { icon: Armchair, label: "Alterar objetos", path: "/change-objects" },
-    { icon: MessageCircle, label: "Edição por Chat", path: "/chat-edit" },
     { icon: RefreshCcwDot, label: "Mudar Estilo", path: "/change-style" },
     { icon: PackagePlus, label: "Completar Cômodo", path: "/improve-render" },
   ];

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { Armchair, PackagePlus, BrushCleaning, RefreshCcwDot, MessageCircle } from "lucide-react";
+import { Armchair, PackagePlus, BrushCleaning, RefreshCcwDot } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -17,12 +17,6 @@ const Home = () => {
       title: "Alterar objetos",
       description: "Substitua itens da imagem por móveis diferentes.",
       link: "/change-objects"
-    },
-    {
-      icon: MessageCircle,
-      title: "Edição por Chat",
-      description: "Altere a imagem descrevendo em texto o que deseja modificar.",
-      link: "/chat-edit"
     },
     {
       icon: RefreshCcwDot,


### PR DESCRIPTION
## Summary
- remove Chat Edit route and sidebar/home entry
- update header to drop Chat Edit title handling
- highlight active mode with purple in `ModeSelector`
- lighten gray background for mode selector buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6882a8fc51c883319688459678f217ae