### PR TITLE
Fix mode selector layout and highlight

### DIFF
--- a/src/components/ModeSelector.tsx
+++ b/src/components/ModeSelector.tsx
@@ -31,7 +31,7 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
         <TooltipTrigger asChild>
           <ToggleGroupItem
             value="texto"
-            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary data-[state=on]:ring-2 data-[state=on]:ring-white"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary data-[state=on]:ring-2 data-[state=on]:ring-white data-[state=on]:ring-offset-2 data-[state=on]:ring-offset-background"
           >
             <Type className="w-4 h-4" />
           </ToggleGroupItem>
@@ -42,7 +42,7 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
         <TooltipTrigger asChild>
           <ToggleGroupItem
             value="inteligente"
-            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary data-[state=on]:ring-2 data-[state=on]:ring-white"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary data-[state=on]:ring-2 data-[state=on]:ring-white data-[state=on]:ring-offset-2 data-[state=on]:ring-offset-background"
           >
             <Sparkles className="w-4 h-4" />
           </ToggleGroupItem>
@@ -53,7 +53,7 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
         <TooltipTrigger asChild>
           <ToggleGroupItem
             value="pincel"
-            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary data-[state=on]:ring-2 data-[state=on]:ring-white"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary data-[state=on]:ring-2 data-[state=on]:ring-white data-[state=on]:ring-offset-2 data-[state=on]:ring-offset-background"
           >
             <Brush className="w-4 h-4" />
           </ToggleGroupItem>
@@ -64,7 +64,7 @@ const ModeSelector = ({ mode, onModeChange, className }: ModeSelectorProps) => {
         <TooltipTrigger asChild>
           <ToggleGroupItem
             value="laco"
-            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary data-[state=on]:ring-2 data-[state=on]:ring-white"
+            className="w-8 h-8 p-0 hover:bg-muted/50 data-[state=on]:bg-primary/20 data-[state=on]:text-primary data-[state=on]:ring-2 data-[state=on]:ring-white data-[state=on]:ring-offset-2 data-[state=on]:ring-offset-background"
           >
             <LassoSelect className="w-4 h-4" />
           </ToggleGroupItem>

--- a/src/components/UploadArea.tsx
+++ b/src/components/UploadArea.tsx
@@ -86,15 +86,19 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, load
       <div className="max-w-5xl mx-auto">
         {/* Main heading */}
         {!preview && (
-          <div className={`mb-3 ${headerRight ? '' : 'text-center'}`}>
-            <div className={`flex items-center ${headerRight ? 'justify-between' : 'justify-center mb-2'}`}>
+          <div className={`mb-3 ${headerRight ? 'relative' : 'text-center'}`}>
+            {headerRight && (
+              <div className="absolute left-0 top-1/2 -translate-y-1/2">
+                {headerRight}
+              </div>
+            )}
+            <div className={`flex items-center justify-center mb-2`}>
               <div className="flex items-center space-x-2">
                 <div className="inline-flex items-center justify-center w-6 h-6 bg-primary/10 rounded-full">
                   <span className="text-sm">1</span>
                 </div>
                 <h2 className="text-lg font-semibold text-foreground">Enviar imagem</h2>
               </div>
-              {headerRight && <div className="ml-2">{headerRight}</div>}
             </div>
             <p className="text-muted-foreground text-xs text-center">
               Faça upload da sua imagem em PNG ou JPEG e siga para as próximas etapas

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -153,7 +153,8 @@ const ChangeObjects = () => {
               image={image}
               loading={loading}
               renderPreview={(img) => (
-                <div className="w-fit mx-auto">
+                <div className="w-fit mx-auto flex flex-col items-start">
+                  <ModeSelector mode={mode} onModeChange={setMode} className="mb-2" />
                   <div className="flex items-center" ref={previewRef}>
                     <div className="relative">
                       {mode === 'inteligente' && (


### PR DESCRIPTION
## Summary
- center upload header while keeping mode selector left-aligned
- keep mode selector visible above the preview image
- add ring offset to highlight selected tools

## Testing
- `npm run lint` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_b_6883bcf143288331be8b29c79f0b77f9