### PR TITLE
Add reference image sidebar

### DIFF
--- a/src/components/DescriptionSidebar.tsx
+++ b/src/components/DescriptionSidebar.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
+import { Maximize2, Minimize2 } from "lucide-react";
 
 interface DescriptionSidebarProps {
   className?: string;
@@ -10,6 +11,8 @@ interface DescriptionSidebarProps {
   onGenerate?: () => void;
   disableGenerate?: boolean;
   hideDescription?: boolean;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
 }
 
 const DescriptionSidebar = ({
@@ -19,16 +22,25 @@ const DescriptionSidebar = ({
   onGenerate,
   disableGenerate,
   hideDescription,
+  collapsed,
+  onToggleCollapse,
 }: DescriptionSidebarProps) => {
   return (
     <div className={cn("w-[25%] mr-8 bg-card rounded-2xl p-4 flex flex-col overflow-y-auto self-stretch", className)}>
-      <div className="flex items-center justify-center mb-2 space-x-2">
-        <div className="inline-flex items-center justify-center w-6 h-6 bg-primary/10 rounded-full">
-          <span className="text-sm">2</span>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center space-x-2">
+          <div className="inline-flex items-center justify-center w-6 h-6 bg-primary/10 rounded-full">
+            <span className="text-sm">2</span>
+          </div>
+          <h2 className="text-lg font-semibold text-foreground">Detalhe sua imagem</h2>
         </div>
-        <h2 className="text-lg font-semibold text-foreground text-center">Detalhe sua imagem</h2>
+        {onToggleCollapse && (
+          <button className="p-1" onClick={onToggleCollapse}>
+            {collapsed ? <Maximize2 className="w-4 h-4" /> : <Minimize2 className="w-4 h-4" />}
+          </button>
+        )}
       </div>
-      {!hideDescription && (
+      {!collapsed && !hideDescription && (
         <>
           <p className="text-sm text-muted-foreground mb-6 text-center">Descreva o que quer mudar</p>
           <div className="space-y-6">
@@ -45,8 +57,7 @@ const DescriptionSidebar = ({
         </>
       )}
 
-      {/* Generate button */}
-      {onGenerate && (
+      {!collapsed && onGenerate && (
         <div className="mt-6">
           <Button variant="gradient" className="w-full flex items-center justify-center" onClick={onGenerate} disabled={disableGenerate}>
             Gerar imagem

--- a/src/components/ReferenceSidebar.tsx
+++ b/src/components/ReferenceSidebar.tsx
@@ -1,0 +1,71 @@
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { useState, useRef } from "react";
+import { Maximize2, Minimize2 } from "lucide-react";
+
+interface ReferenceSidebarProps {
+  className?: string;
+  onGenerate?: () => void;
+  disableGenerate?: boolean;
+  collapsed?: boolean;
+  onToggleCollapse?: () => void;
+  onImageSelected?: (file: File | null) => void;
+}
+
+const ReferenceSidebar = ({
+  className,
+  onGenerate,
+  disableGenerate,
+  collapsed,
+  onToggleCollapse,
+  onImageSelected,
+}: ReferenceSidebarProps) => {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [file, setFile] = useState<File | null>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0] || null;
+    setFile(f);
+    onImageSelected?.(f);
+  };
+
+  return (
+    <div className={cn("w-[25%] mr-8 bg-card rounded-2xl p-4 flex flex-col overflow-y-auto self-stretch", className)}>
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center space-x-2">
+          <div className="inline-flex items-center justify-center w-6 h-6 bg-primary/10 rounded-full">
+            <span className="text-sm">3</span>
+          </div>
+          <h2 className="text-lg font-semibold text-foreground">Imagem de referência (opcional)</h2>
+        </div>
+        {onToggleCollapse && (
+          <button className="p-1" onClick={onToggleCollapse}>
+            {collapsed ? <Maximize2 className="w-4 h-4" /> : <Minimize2 className="w-4 h-4" />}
+          </button>
+        )}
+      </div>
+      {!collapsed && (
+        <>
+          <div className="space-y-2 mb-4">
+            <Label className="text-sm font-medium text-foreground">Enviar imagem de referência</Label>
+            <Input ref={fileInputRef} type="file" accept="image/*" onChange={handleFileChange} />
+          </div>
+          {onGenerate && (
+            <Button
+              variant="gradient"
+              className="w-full flex items-center justify-center mt-auto"
+              onClick={onGenerate}
+              disabled={disableGenerate}
+            >
+              Gerar imagem
+            </Button>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ReferenceSidebar;

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -5,6 +5,7 @@ import BrushSelector, { BrushSelectorHandle } from "@/components/BrushSelector";
 import LassoSelector, { LassoSelectorHandle } from "@/components/LassoSelector";
 import ModeSelector from "@/components/ModeSelector";
 import DescriptionSidebar from "@/components/DescriptionSidebar";
+import ReferenceSidebar from "@/components/ReferenceSidebar";
 import { useState, useRef, useEffect } from "react";
 import { Button } from "@/components/ui/button";
 import { Save, Download, Maximize2, Minimize2 } from "lucide-react";
@@ -24,6 +25,9 @@ const ChangeObjects = () => {
   const [prompt, setPrompt] = useState("");
   const [mode, setMode] = useState("texto");
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [descCollapsed, setDescCollapsed] = useState(false);
+  const [refCollapsed, setRefCollapsed] = useState(true);
+  const [refImage, setRefImage] = useState<File | null>(null);
 
   const previewRef = useRef<HTMLDivElement>(null);
 
@@ -79,6 +83,15 @@ const ChangeObjects = () => {
   const handleUpload = (dataUrl: string) => {
     setImage(dataUrl);
     setOriginalImage(dataUrl);
+  };
+
+  const toggleDesc = () => setDescCollapsed(v => !v);
+  const toggleRef = () => {
+    setRefCollapsed(v => {
+      const newVal = !v;
+      if (!newVal) setDescCollapsed(true);
+      return newVal;
+    });
   };
 
   async function blobToDataURL(blob: Blob): Promise<string> {
@@ -216,13 +229,23 @@ const ChangeObjects = () => {
           </div>
         </div>
 
-        <DescriptionSidebar
-          description={prompt}
-          onDescriptionChange={setPrompt}
-          onGenerate={handleGenerate}
-          disableGenerate={loading}
-          className="mr-6 mt-2 self-start flex-none"
-        />
+        <div className="mr-6 mt-2 self-start flex-none flex flex-col space-y-4">
+          <DescriptionSidebar
+            description={prompt}
+            onDescriptionChange={setPrompt}
+            onGenerate={handleGenerate}
+            disableGenerate={loading}
+            collapsed={descCollapsed}
+            onToggleCollapse={toggleDesc}
+          />
+          <ReferenceSidebar
+            onGenerate={handleGenerate}
+            disableGenerate={loading}
+            collapsed={refCollapsed}
+            onToggleCollapse={toggleRef}
+            onImageSelected={setRefImage}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add collapsible `ReferenceSidebar` for optional reference images
- allow collapsing in `DescriptionSidebar`
- integrate new sidebar and collapse logic in `ChangeObjects` page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6887dabe6b3883318ee48f694c047264