### PR TITLE
Enhance sidebars and add reference image removal

### DIFF
--- a/src/components/DescriptionSidebar.tsx
+++ b/src/components/DescriptionSidebar.tsx
@@ -32,15 +32,15 @@ const DescriptionSidebar = ({
         className
       )}
     >
-      <div className="flex items-center justify-between mb-2">
+      <div className="relative flex items-center justify-center mb-2 pr-6">
         <div className="flex items-center space-x-2">
           <div className="inline-flex items-center justify-center w-6 h-6 bg-primary/10 rounded-full">
             <span className="text-sm">2</span>
           </div>
-          <h2 className="text-lg font-semibold text-foreground">Detalhe sua imagem</h2>
+          <h2 className="text-lg font-semibold text-foreground text-center">Detalhe sua imagem</h2>
         </div>
         {onToggleCollapse && (
-          <button className="p-1" onClick={onToggleCollapse}>
+          <button className="p-1 absolute right-0" onClick={onToggleCollapse}>
             {collapsed ? (
               <ChevronDown className="w-4 h-4" />
             ) : (

--- a/src/components/ReferenceSidebar.tsx
+++ b/src/components/ReferenceSidebar.tsx
@@ -3,7 +3,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
 import { useState, useRef } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, X } from "lucide-react";
 
 interface ReferenceSidebarProps {
   className?: string;
@@ -46,15 +46,15 @@ const ReferenceSidebar = ({
         className
       )}
     >
-      <div className="flex items-center justify-between mb-2">
+      <div className="relative flex items-center justify-center mb-2 pr-6">
         <div className="flex items-center space-x-2">
           <div className="inline-flex items-center justify-center w-6 h-6 bg-primary/10 rounded-full">
             <span className="text-sm">3</span>
           </div>
-          <h2 className="text-lg font-semibold text-foreground">Imagem de referência (opcional)</h2>
+          <h2 className="text-lg font-semibold text-foreground text-center">Imagem de referência (opcional)</h2>
         </div>
         {onToggleCollapse && (
-          <button className="p-1" onClick={onToggleCollapse}>
+          <button className="p-1 absolute right-0" onClick={onToggleCollapse}>
             {collapsed ? (
               <ChevronDown className="w-4 h-4" />
             ) : (
@@ -70,11 +70,24 @@ const ReferenceSidebar = ({
             <Input ref={fileInputRef} type="file" accept="image/*" onChange={handleFileChange} />
             {preview && (
               <div className="mt-2 flex justify-center">
-                <img
-                  src={preview}
-                  alt="Pré-visualização"
-                  className="max-h-32 rounded object-contain"
-                />
+                <div className="relative">
+                  <img
+                    src={preview}
+                    alt="Pré-visualização"
+                    className="max-h-32 rounded object-contain"
+                  />
+                  <button
+                    className="absolute top-1 right-1 bg-background/70 rounded-full p-1"
+                    onClick={() => {
+                      setFile(null);
+                      setPreview(null);
+                      onImageSelected?.(null);
+                      if (fileInputRef.current) fileInputRef.current.value = "";
+                    }}
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
               </div>
             )}
           </div>

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -229,7 +229,7 @@ const ChangeObjects = () => {
           </div>
         </div>
 
-        <div className="mr-6 mt-2 self-start flex-none flex flex-col space-y-4">
+        <div className="mr-2 mt-2 self-start flex-none flex flex-col space-y-4">
           <DescriptionSidebar
             description={prompt}
             onDescriptionChange={setPrompt}
@@ -237,6 +237,7 @@ const ChangeObjects = () => {
             disableGenerate={loading}
             collapsed={descCollapsed}
             onToggleCollapse={toggleDesc}
+            className="w-[480px] mr-4"
           />
           <ReferenceSidebar
             onGenerate={handleGenerate}
@@ -244,6 +245,7 @@ const ChangeObjects = () => {
             collapsed={refCollapsed}
             onToggleCollapse={toggleRef}
             onImageSelected={setRefImage}
+            className="w-[480px] mr-4"
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- center titles in DescriptionSidebar and ReferenceSidebar
- add button to remove reference image
- allow larger sidebars on ChangeObjects page

## Testing
- `npm run lint` *(fails: Cannot find package `globals` in eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_6888da19f6108331b4c59d761d18659c