### PR TITLE
Refine Change Objects UI

### DIFF
--- a/src/components/DescriptionSidebar.tsx
+++ b/src/components/DescriptionSidebar.tsx
@@ -113,10 +113,11 @@ const DescriptionSidebar = ({
                 <>
                   {!preview && (
                     <div className="p-4 rounded-lg border-2 border-dashed border-primary bg-white text-center space-y-2 w-72 mx-auto">
-                      <p className="text-sm text-muted-foreground">Arraste ou clique no botão abaixo para enviar</p>
+                      <p className="text-xs text-muted-foreground">Arraste ou clique no botão abaixo para enviar</p>
                       <Button
                         variant="outline"
-                        className="border-2 border-gray-300 bg-white hover:bg-gray-100 text-foreground rounded-lg inline-flex items-center"
+                        size="sm"
+                        className="border-2 border-gray-300 bg-white hover:bg-white hover:brightness-110 text-foreground rounded-lg inline-flex items-center"
                         onClick={() => fileInputRef.current?.click()}
                       >
                         <Upload className="w-4 h-4 mr-2" />

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -156,8 +156,8 @@ const ChangeObjects = () => {
               image={image}
               loading={loading}
               renderPreview={(img) => (
-                <div className="w-fit mx-auto flex flex-col items-start">
-                  <ModeSelector mode={mode} onModeChange={setMode} className="mb-2" />
+                <div className="w-fit flex flex-col items-start self-start">
+                  <ModeSelector mode={mode} onModeChange={setMode} className="mb-2 self-start" />
                   <div className="flex items-center" ref={previewRef}>
                     <div className="relative">
                       {mode === 'inteligente' && (


### PR DESCRIPTION
## Summary
- align mode selector to the left in Change Objects page
- shrink reference upload instructions and button
- lighten hover effect on reference upload button

## Testing
- `npm run lint` *(fails: Cannot find package 'globals' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_b_68890ff3b79083319e53ca5199a1674d