### PR TITLE
Adjust mode selector position

### DIFF
--- a/src/components/UploadArea.tsx
+++ b/src/components/UploadArea.tsx
@@ -111,7 +111,7 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, load
         {/* Upload area with prompt, preview and button inside larger dashed box */}
         <div className="bg-card rounded-xl px-8 py-2 text-center mb-1 mx-auto max-w-4xl relative">
         {overlayLeft && (
-          <div className="absolute top-2 left-2 z-10">
+          <div className="absolute -top-6 -left-6 z-10">
             {overlayLeft}
           </div>
         )}


### PR DESCRIPTION
## Summary
- move mode selector further top-left within the upload area

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688914ef190c8331aa5432d479cd69a9