### PR TITLE
Fix mask storage and show mode selector

### DIFF
--- a/src/components/UploadArea.tsx
+++ b/src/components/UploadArea.tsx
@@ -111,7 +111,9 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, load
         {/* Upload area with prompt, preview and button inside larger dashed box */}
         <div className="bg-card rounded-xl px-8 py-2 text-center mb-1 mx-auto max-w-4xl relative">
         {overlayLeft && (
-          <div className="absolute -top-14 -left-12 z-10">
+          <div
+            className={`absolute ${preview ? 'top-2 left-2' : '-top-14 -left-12'} z-10`}
+          >
             {overlayLeft}
           </div>
         )}

--- a/src/hooks/useGenerations.ts
+++ b/src/hooks/useGenerations.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 export interface Generation {
   id: string;
   image: string;
+  mask?: string;
   date: string;
 }
 
@@ -50,8 +51,8 @@ export default function useGenerations() {
     };
   }, []);
 
-  const addGeneration = (image: string) => {
-    const gen: Generation = { id: Date.now().toString(), image, date: new Date().toISOString() };
+  const addGeneration = (image: string, mask?: string) => {
+    const gen: Generation = { id: Date.now().toString(), image, mask, date: new Date().toISOString() };
     const updated = [gen, ...loadGenerations()];
     saveGenerations(updated);
   };

--- a/src/pages/.ipynb_checkpoints/ChatEdit-checkpoint.tsx
+++ b/src/pages/.ipynb_checkpoints/ChatEdit-checkpoint.tsx
@@ -35,7 +35,7 @@ const ChatEdit = () => {
       const outBlob = await res.blob();
       const dataUrl = await blobToDataURL(outBlob);
       setImage(dataUrl);
-      addGeneration(dataUrl);
+      addGeneration(dataUrl, null);
     } catch (err) {
       console.error("chat edit failed", err);
     } finally {

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -112,7 +112,7 @@ const ChangeObjects = () => {
         const outBlob = await res.blob();
         const dataUrl = await blobToDataURL(outBlob);
         setImage(dataUrl);
-        addGeneration(dataUrl);
+        addGeneration(dataUrl, null);
       } else {
         let maskData: string | null = null;
         if (mode === 'inteligente') maskData = selectorRef.current?.exportMask() ?? null;
@@ -126,7 +126,7 @@ const ChangeObjects = () => {
         const outBlob = await res.blob();
         const dataUrl = await blobToDataURL(outBlob);
         setImage(dataUrl);
-        addGeneration(dataUrl);
+        addGeneration(dataUrl, maskData);
         selectorRef.current?.resetSelections();
         brushRef.current?.resetSelections();
         lassoRef.current?.resetSelections();

--- a/src/pages/ChangeStyle.tsx
+++ b/src/pages/ChangeStyle.tsx
@@ -34,7 +34,7 @@ const ChangeStyle = () => {
       const outBlob = await res.blob();
       const dataUrl = await blobToDataURL(outBlob);
       setImage(dataUrl);
-      addGeneration(dataUrl);
+      addGeneration(dataUrl, null);
     } catch (err) {
       console.error('style generation failed', err);
     } finally {

--- a/src/pages/ChatEdit.tsx
+++ b/src/pages/ChatEdit.tsx
@@ -37,7 +37,7 @@ const ChatEdit = () => {
       const outBlob = await res.blob();
       const dataUrl = await blobToDataURL(outBlob);
       setImage(dataUrl);
-      addGeneration(dataUrl);
+      addGeneration(dataUrl, null);
     } catch (err) {
       console.error("chat edit failed", err);
     } finally {


### PR DESCRIPTION
## Summary
- keep mode selector positioned when an image is uploaded
- store masks with generated images
- update all addGeneration calls to pass mask info

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_b_68891c9e055883319180f1f280a39a52