### PR TITLE
Fix overlay position

### DIFF
--- a/src/components/UploadArea.tsx
+++ b/src/components/UploadArea.tsx
@@ -111,9 +111,7 @@ const UploadArea = ({ onImageSelected, onRemoveImage, renderPreview, image, load
         {/* Upload area with prompt, preview and button inside larger dashed box */}
         <div className="bg-card rounded-xl px-8 py-2 text-center mb-1 mx-auto max-w-4xl relative">
         {overlayLeft && (
-          <div
-            className={`absolute ${preview ? 'top-2 left-2' : '-top-14 -left-12'} z-10`}
-          >
+          <div className="absolute -top-14 -left-12 z-10">
             {overlayLeft}
           </div>
         )}


### PR DESCRIPTION
## Summary
- keep ModeSelector overlay position stable regardless of preview

## Testing
- `npm run lint` *(fails: Cannot find package 'globals/index.js')*

------
https://chatgpt.com/codex/tasks/task_b_688920b6402c8331b966806a6677fa31