### PR TITLE
Show masks in generations gallery

### DIFF
--- a/src/components/PreviousGenerations.tsx
+++ b/src/components/PreviousGenerations.tsx
@@ -38,7 +38,7 @@ const PreviousGenerations = ({ onSelect }: PreviousGenerationsProps) => {
             {generations.map(image => (
               <div
                 key={image.id}
-                className="flex-shrink-0 w-20 h-20 bg-muted rounded-lg overflow-hidden cursor-pointer hover:opacity-80 transition-opacity"
+                className="relative flex-shrink-0 w-20 h-20 bg-muted rounded-lg overflow-hidden cursor-pointer hover:opacity-80 transition-opacity"
                 onDoubleClick={() => onSelect?.(image.image)}
                 draggable
                 onDragStart={e => {
@@ -46,6 +46,9 @@ const PreviousGenerations = ({ onSelect }: PreviousGenerationsProps) => {
                 }}
               >
                 <img src={image.image} alt="geração" className="w-full h-full object-cover" />
+                {image.mask && (
+                  <img src={image.mask} alt="máscara" className="absolute inset-0 w-full h-full object-cover opacity-50 pointer-events-none" />
+                )}
               </div>
             ))}
           </div>

--- a/src/pages/Generations.tsx
+++ b/src/pages/Generations.tsx
@@ -77,6 +77,13 @@ const Generations = () => {
                   alt={`Generation ${item.id}`}
                   className="w-full h-full object-cover"
                 />
+                {item.mask && (
+                  <img
+                    src={item.mask}
+                    alt="Mask"
+                    className="absolute inset-0 w-full h-full object-cover opacity-50 pointer-events-none"
+                  />
+                )}
               </div>
             ))}
           </div>
@@ -86,12 +93,19 @@ const Generations = () => {
               <Carousel opts={{ loop: true }} setApi={setCarouselApi} className="relative">
                 <CarouselContent>
                   {sortedGenerations.map((item) => (
-                    <CarouselItem key={item.id} className="flex items-center justify-center">
+                    <CarouselItem key={item.id} className="flex items-center justify-center relative">
                       <img
                         src={item.image}
                         alt={`Generation ${item.id}`}
                         className="max-h-[80vh] w-full object-contain"
                       />
+                      {item.mask && (
+                        <img
+                          src={item.mask}
+                          alt="Mask"
+                          className="absolute inset-0 max-h-[80vh] w-full object-contain opacity-50 pointer-events-none"
+                        />
+                      )}
                     </CarouselItem>
                   ))}
                 </CarouselContent>


### PR DESCRIPTION
## Summary
- overlay mask images on previous generation thumbnails
- display mask overlays in the generations gallery grid and carousel

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_68892db8164883318c5a494d25f4a876