### PR TITLE
Fix inpaint pipeline and generation storage

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -166,13 +166,13 @@ print("loading Flux Kontext pipeline")
 #flux_pipe.to("cuda")
 #integrity_checker = PixtralContentFilter(torch.device("cuda"))
 
-# Initialize Flux Kontext inpainting pipeline (temporarily disabled)
-# check_min_version("0.30.2")
-# inpaint_pipe = FluxKontextInpaintPipeline.from_pretrained(
-#     "black-forest-labs/FLUX.1-Kontext-dev",
-#     torch_dtype=torch.bfloat16,
-# )
-# inpaint_pipe.to("cuda")
+# Initialize Flux Kontext inpainting pipeline
+check_min_version("0.30.2")
+inpaint_pipe = FluxKontextInpaintPipeline.from_pretrained(
+    "black-forest-labs/FLUX.1-Kontext-dev",
+    torch_dtype=torch.bfloat16,
+)
+inpaint_pipe.to("cuda")
 
 # Style prompts in Portuguese
 style_prompts = {
@@ -238,17 +238,16 @@ def process_image(image: Image.Image, style_selection: str) -> Image.Image:
 def inpaint_image(image: Image.Image, mask: Image.Image, prompt: str, image_reference: Image.Image | None) -> Image.Image:
     image = image.convert("RGB")
     mask = mask.convert("RGB")
-    # Temporarily return the mask instead of performing inpainting
-    # mask = inpaint_pipe.mask_processor.blur(mask, blur_factor=12)
-    # result = inpaint_pipe(
-    #     prompt=prompt,
-    #     image=image,
-    #     mask_image=mask,
-    #     image_reference=image_reference if image_reference is not None else image,
-    #     strength=1.0,
-    # ).images[0]
+    mask = inpaint_pipe.mask_processor.blur(mask, blur_factor=12)
+    result = inpaint_pipe(
+        prompt=prompt,
+        image=image,
+        mask_image=mask,
+        image_reference=image_reference if image_reference is not None else image,
+        strength=1.0,
+    ).images[0]
 
-    return mask
+    return result
 
 @app.post("/detect")
 def detect_objects():

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -112,7 +112,7 @@ const ChangeObjects = () => {
         const outBlob = await res.blob();
         const dataUrl = await blobToDataURL(outBlob);
         setImage(dataUrl);
-        addGeneration(dataUrl, null);
+        addGeneration(dataUrl);
       } else {
         let maskData: string | null = null;
         if (mode === 'inteligente') maskData = selectorRef.current?.exportMask() ?? null;
@@ -126,7 +126,7 @@ const ChangeObjects = () => {
         const outBlob = await res.blob();
         const dataUrl = await blobToDataURL(outBlob);
         setImage(dataUrl);
-        addGeneration(dataUrl, maskData);
+        addGeneration(dataUrl);
         selectorRef.current?.resetSelections();
         brushRef.current?.resetSelections();
         lassoRef.current?.resetSelections();


### PR DESCRIPTION
## Summary
- react: store only generated images in ChangeObjects page
- backend: enable Flux Kontext inpainting pipeline and return results

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68893bad95dc83318cc639c007186469