### PR TITLE
Improve Complete Room flow with style selector and item entry

### DIFF
--- a/src/components/CompleteRoomSidebar.tsx
+++ b/src/components/CompleteRoomSidebar.tsx
@@ -1,8 +1,28 @@
 import { Button } from "@/components/ui/button";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import React, { useState } from "react";
 import { cn } from "@/lib/utils";
+
+const styles = [
+  "Nenhum",
+  "Minimalista",
+  "Boêmio",
+  "Fazenda",
+  "Príncipe Saudita",
+  "Neoclássico",
+  "Eclético",
+  "Parisiense",
+  "Hollywood",
+  "Escandinavo",
+  "Praia",
+  "Japonês",
+  "Meados do Século Moderno",
+  "Retro-futurismo",
+  "Texano",
+  "Matrix",
+];
 
 interface CompleteRoomSidebarProps {
   className?: string;
@@ -10,6 +30,9 @@ interface CompleteRoomSidebarProps {
   onRoomChange?: (room: string) => void;
   items: string[];
   onRemoveItem?: (item: string) => void;
+  onAddItem?: (item: string) => void;
+  style: string;
+  onStyleChange?: (style: string) => void;
   onGenerate?: () => void;
   disableGenerate?: boolean;
 }
@@ -20,9 +43,24 @@ const CompleteRoomSidebar = ({
   onRoomChange,
   items,
   onRemoveItem,
+  onAddItem,
+  style,
+  onStyleChange,
   onGenerate,
   disableGenerate,
 }: CompleteRoomSidebarProps) => {
+  const [newItem, setNewItem] = useState("");
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      const value = newItem.trim();
+      if (value) {
+        onAddItem?.(value);
+        setNewItem("");
+      }
+    }
+  };
   return (
     <div className={cn("w-[25%] mr-8 bg-card rounded-2xl p-4 flex flex-col overflow-y-auto self-stretch", className)}>
       <div className="flex items-center justify-center mb-2 space-x-2">
@@ -54,11 +92,11 @@ const CompleteRoomSidebar = ({
 
         <div className="space-y-2">
           <Label className="text-sm font-medium text-foreground">Móveis sugeridos</Label>
-          <Textarea
-            placeholder="Digite aqui..."
-            className="min-h-[100px] resize-none"
-            readOnly
-            value={items.join(', ')}
+          <Input
+            placeholder="Digite e pressione Enter"
+            value={newItem}
+            onChange={(e) => setNewItem(e.target.value)}
+            onKeyDown={handleKeyDown}
           />
           {items.length > 0 && (
             <div className="flex flex-wrap gap-1 mt-1">
@@ -74,6 +112,20 @@ const CompleteRoomSidebar = ({
               ))}
             </div>
           )}
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-sm font-medium text-foreground">Estilo</Label>
+          <Select value={style} onValueChange={onStyleChange}>
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {styles.map((s) => (
+                <SelectItem key={s} value={s.toLowerCase().replace(/\s+/g, '-')}>{s}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
       </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,6 +21,31 @@ const ROOM_LABEL: Record<string, string> = {
   "banheiro": "banheiro",
 };
 
+const STYLES = [
+  "Nenhum",
+  "Minimalista",
+  "Boêmio",
+  "Fazenda",
+  "Príncipe Saudita",
+  "Neoclássico",
+  "Eclético",
+  "Parisiense",
+  "Hollywood",
+  "Escandinavo",
+  "Praia",
+  "Japonês",
+  "Meados do Século Moderno",
+  "Retro-futurismo",
+  "Texano",
+  "Matrix",
+];
+
+const STYLE_LABEL: Record<string, string> = STYLES.reduce((acc, s) => {
+  const key = s.toLowerCase().replace(/\s+/g, '-');
+  acc[key] = s.toLowerCase();
+  return acc;
+}, {} as Record<string, string>);
+
 async function blobToDataURL(blob: Blob): Promise<string> {
   return new Promise((resolve) => {
     const reader = new FileReader();
@@ -34,6 +59,7 @@ const Index = () => {
   const [image, setImage] = useState<string | null>(null);
   const [room, setRoom] = useState<string>("sala-estar");
   const [items, setItems] = useState<string[]>(ROOM_OBJECTS["sala-estar"]);
+  const [style, setStyle] = useState<string>("nenhum");
   const [loading, setLoading] = useState(false);
 
   const handleRoomChange = (r: string) => {
@@ -45,6 +71,10 @@ const Index = () => {
     setItems((prev) => prev.filter((i) => i !== it));
   };
 
+  const handleAddItem = (it: string) => {
+    setItems((prev) => [...prev, it]);
+  };
+
   const handleUpload = (dataUrl: string) => {
     setImage(dataUrl);
   };
@@ -54,7 +84,7 @@ const Index = () => {
     setLoading(true);
     try {
       const prompt = `${items.map((i) => `Adicionar ${i}`).join(", ")}.
-        A ${ROOM_LABEL[room]} deve ficar harmônica e elegante.`;
+        A ${ROOM_LABEL[room]} deve ficar harmônica e elegante${style !== "nenhum" ? ` com estilo ${STYLE_LABEL[style]}` : ""}.`;
       const translated = await translateToEnglish(prompt);
       const blob = await fetch(image).then((r) => r.blob());
       const form = new FormData();
@@ -97,6 +127,9 @@ const Index = () => {
           onRoomChange={handleRoomChange}
           items={items}
           onRemoveItem={handleRemoveItem}
+          onAddItem={handleAddItem}
+          style={style}
+          onStyleChange={setStyle}
           onGenerate={handleGenerate}
           disableGenerate={loading}
         />


### PR DESCRIPTION
## Summary
- add style options and item input handling to `CompleteRoomSidebar`
- keep new style state in index page and include style in prompts
- allow entering custom items via input and pressing Enter

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688ba3320488833183374fe3ed9e5f76