### PR TITLE
Improve room completion randomness

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -309,7 +309,14 @@ def flux_edit():
         return jsonify({"error": "image and prompt required"}), 400
     print(prompt)
     img = Image.open(file.stream).convert("RGB")
-    image = flux_pipe(image=img, prompt=prompt, guidance_scale=2.5).images[0]
+    seed = random.randint(0, MAX_SEED)
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    image = flux_pipe(
+        image=img,
+        prompt=prompt,
+        guidance_scale=2.5,
+        generator=generator,
+    ).images[0]
     image_ = np.array(image) / 255.0
     image_ = 2 * image_ - 1
     image_ = (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -83,8 +83,11 @@ const Index = () => {
     if (!image) return;
     setLoading(true);
     try {
-      const prompt = `${items.map((i) => `Adicionar ${i}`).join(", ")}.
-        A ${ROOM_LABEL[room]} deve ficar harmônica e elegante${style !== "nenhum" ? ` com estilo ${STYLE_LABEL[style]}` : ""}.`;
+      const prompt = `${items
+        .map((i) => `Adicionar ${i}`)
+        .join(", ")}. A ${ROOM_LABEL[room]} deve ficar harmônica e elegante${
+        style !== "nenhum" ? ` com estilo ${STYLE_LABEL[style]}` : ""
+      }.`;
       const translated = await translateToEnglish(prompt);
       const blob = await fetch(image).then((r) => r.blob());
       const form = new FormData();


### PR DESCRIPTION
## Summary
- randomize flux pipeline seed so successive generations are different
- keep style prompt on the same line when completing rooms

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_688bb0f1eb388331b02193fb36527cd2