### PR TITLE
Position mode selector next to upload header

### DIFF
--- a/src/pages/.ipynb_checkpoints/ChangeObjects-checkpoint.tsx
+++ b/src/pages/.ipynb_checkpoints/ChangeObjects-checkpoint.tsx
@@ -152,7 +152,7 @@ const ChangeObjects = () => {
         <div className="flex-1 flex flex-col px-2 pt-2 pb-8">
           <div className="bg-card rounded-2xl overflow-hidden border border-border w-full max-w-5xl mx-auto">
             <UploadArea
-              overlayLeft={<ModeSelector mode={mode} onModeChange={setMode} />}
+              headerRight={<ModeSelector mode={mode} onModeChange={setMode} />}
               onImageSelected={handleUpload}
               onRemoveImage={() =>
                 originalImage && setImage(originalImage)

--- a/src/pages/ChangeObjects.tsx
+++ b/src/pages/ChangeObjects.tsx
@@ -152,7 +152,7 @@ const ChangeObjects = () => {
         <div className="flex-1 flex flex-col px-2 pt-2 pb-8">
           <div className="bg-card rounded-2xl overflow-hidden border border-border w-full max-w-5xl mx-auto">
             <UploadArea
-              overlayLeft={<ModeSelector mode={mode} onModeChange={setMode} />}
+              headerRight={<ModeSelector mode={mode} onModeChange={setMode} />}
               onImageSelected={handleUpload}
               onRemoveImage={() =>
                 originalImage && setImage(originalImage)


### PR DESCRIPTION
## Summary
- adjust ChangeObjects page to pass `headerRight` into `UploadArea`
- update checkpoint file accordingly

## Testing
- `npm run lint` *(fails: 38 errors, 13 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_688d0a3fc0a08331865dd8dc54ef3dda